### PR TITLE
feat(anthropic,fireworks,openai): use LangSmith gateway keys

### DIFF
--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -78,6 +78,11 @@ _message_type_lookups = {
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
 
 _LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/anthropic"
+_LANGSMITH_GATEWAY_API_KEY_ENV_VARS = (
+    "LANGSMITH_GATEWAY_API_KEY",
+    "LANGSMITH_API_KEY",
+    "LANGCHAIN_API_KEY",
+)
 
 
 def _resolve_gateway_base_url() -> str | None:
@@ -87,6 +92,10 @@ def _resolve_gateway_base_url() -> str | None:
     if raw.lower() in ("true", "1", "yes"):
         return _LANGSMITH_GATEWAY_DEFAULT_URL
     return raw
+
+
+def _resolve_gateway_api_key() -> SecretStr | None:
+    return secret_from_env(_LANGSMITH_GATEWAY_API_KEY_ENV_VARS, default=None)()
 
 
 _USER_AGENT: Final[str] = f"langchain-anthropic/{__version__}"
@@ -974,18 +983,17 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=lambda: SecretStr(
-            (
-                os.getenv("LANGSMITH_GATEWAY_API_KEY")
-                if _resolve_gateway_base_url() is not None
-                else None
-            )
-            or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
-        ),
+        default_factory=lambda: (
+            _resolve_gateway_api_key()
+            if _resolve_gateway_base_url() is not None
+            else None
+        )
+        or secret_from_env("ANTHROPIC_API_KEY", default="")(),
     )
     """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY`,
+    `LANGSMITH_API_KEY`, and `LANGCHAIN_API_KEY` take precedence.
     """
 
     anthropic_proxy: str | None = Field(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -974,9 +974,15 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env("ANTHROPIC_API_KEY", default=""),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
+        ),
     )
-    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided."""
+    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    """
 
     anthropic_proxy: str | None = Field(
         default_factory=from_env("ANTHROPIC_PROXY", default=None)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import hashlib
 import json
+import os
 import re
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
@@ -75,6 +76,18 @@ _message_type_lookups = {
 }
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/anthropic"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 _USER_AGENT: Final[str] = f"langchain-anthropic/{__version__}"
 
@@ -945,15 +958,18 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_url: str | None = Field(
         alias="base_url",
-        default_factory=from_env(
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env(
             ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
             default="https://api.anthropic.com",
-        ),
+        )(),
     )
     """Base URL for API requests. Only specify if using a proxy or service emulator.
 
     If a value isn't passed in, will attempt to read the value first from
     `ANTHROPIC_API_URL` and if that is not set, `ANTHROPIC_BASE_URL`.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over both env vars.
     """
 
     anthropic_api_key: SecretStr = Field(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -975,13 +975,17 @@ class ChatAnthropic(BaseChatModel):
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
         ),
     )
     """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     anthropic_proxy: str | None = Field(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3574,3 +3574,27 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://gateway.smith.langchain.com/anthropic"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3606,3 +3606,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3608,6 +3608,47 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert llm.anthropic_api_key.get_secret_value() == "gateway-key"
 
 
+@pytest.mark.parametrize(
+    ("env_var", "expected"),
+    [
+        ("LANGSMITH_API_KEY", "langsmith-key"),
+        ("LANGCHAIN_API_KEY", "langchain-key"),
+    ],
+)
+def test_langsmith_gateway_api_key_langsmith_fallbacks(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, expected: str
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv(env_var, expected)
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == expected
+
+
+def test_langsmith_gateway_api_key_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "langchain-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_explicit_api_key_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="explicit-key")
+    assert llm.anthropic_api_key.get_secret_value() == "explicit-key"
+
+
 def test_langsmith_gateway_api_key_not_used_without_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3598,3 +3598,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
     assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -110,6 +110,11 @@ logger = logging.getLogger(__name__)
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
 
 _LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/fireworks"
+_LANGSMITH_GATEWAY_API_KEY_ENV_VARS = (
+    "LANGSMITH_GATEWAY_API_KEY",
+    "LANGSMITH_API_KEY",
+    "LANGCHAIN_API_KEY",
+)
 
 
 def _resolve_gateway_base_url() -> str | None:
@@ -119,6 +124,10 @@ def _resolve_gateway_base_url() -> str | None:
     if raw.lower() in ("true", "1", "yes"):
         return _LANGSMITH_GATEWAY_DEFAULT_URL
     return raw
+
+
+def _resolve_gateway_api_key() -> SecretStr | None:
+    return secret_from_env(_LANGSMITH_GATEWAY_API_KEY_ENV_VARS, default=None)()
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -768,27 +777,26 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=lambda: SecretStr(
-            (
-                os.getenv("LANGSMITH_GATEWAY_API_KEY")
-                if _resolve_gateway_base_url() is not None
-                else None
-            )
-            or secret_from_env(
-                "FIREWORKS_API_KEY",
-                error_message=(
-                    "You must specify an api key. "
-                    "You can pass it an argument as `api_key=...` or "
-                    "set the environment variable `FIREWORKS_API_KEY`."
-                ),
-            )().get_secret_value()
-        ),
+        default_factory=lambda: (
+            _resolve_gateway_api_key()
+            if _resolve_gateway_base_url() is not None
+            else None
+        )
+        or secret_from_env(
+            "FIREWORKS_API_KEY",
+            error_message=(
+                "You must specify an api key. "
+                "You can pass it an argument as `api_key=...` or "
+                "set the environment variable `FIREWORKS_API_KEY`."
+            ),
+        )(),
     )
     """Fireworks API key.
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY`,
+    `LANGSMITH_API_KEY`, and `LANGCHAIN_API_KEY` take precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
 from typing import (
@@ -107,6 +108,17 @@ logger = logging.getLogger(__name__)
 
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/fireworks"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -771,10 +783,14 @@ class ChatFireworks(BaseChatModel):
     """
 
     fireworks_api_base: str | None = Field(
-        alias="base_url", default_factory=from_env("FIREWORKS_API_BASE", default=None)
+        alias="base_url",
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env("FIREWORKS_API_BASE", default=None)(),
     )
     """Base URL path for API requests, leave blank if not using a proxy or service
     emulator.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over `FIREWORKS_API_BASE`.
     """
 
     request_timeout: float | tuple[float, float] | Any | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -769,7 +769,11 @@ class ChatFireworks(BaseChatModel):
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env(
                 "FIREWORKS_API_KEY",
                 error_message=(
@@ -784,7 +788,7 @@ class ChatFireworks(BaseChatModel):
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -768,18 +768,23 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            "FIREWORKS_API_KEY",
-            error_message=(
-                "You must specify an api key. "
-                "You can pass it an argument as `api_key=...` or "
-                "set the environment variable `FIREWORKS_API_KEY`."
-            ),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env(
+                "FIREWORKS_API_KEY",
+                error_message=(
+                    "You must specify an api key. "
+                    "You can pass it an argument as `api_key=...` or "
+                    "set the environment variable `FIREWORKS_API_KEY`."
+                ),
+            )().get_secret_value()
         ),
     )
     """Fireworks API key.
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1621,6 +1621,47 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert llm.fireworks_api_key.get_secret_value() == "gateway-key"
 
 
+@pytest.mark.parametrize(
+    ("env_var", "expected"),
+    [
+        ("LANGSMITH_API_KEY", "langsmith-key"),
+        ("LANGCHAIN_API_KEY", "langchain-key"),
+    ],
+)
+def test_langsmith_gateway_api_key_langsmith_fallbacks(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, expected: str
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    monkeypatch.setenv(env_var, expected)
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == expected
+
+
+def test_langsmith_gateway_api_key_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "langchain-key")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "provider-key")
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_explicit_api_key_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    llm = ChatFireworks(model=MODEL_NAME, api_key="explicit-key")  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "explicit-key"
+
+
 def test_langsmith_gateway_api_key_not_used_without_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1619,3 +1619,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
     llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
     assert llm.fireworks_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "provider-key")
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1611,3 +1611,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
     llm = _make_model()
     assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1591,3 +1591,23 @@ def test_request_timeout_tuple_normalized_to_httpx_timeout(
     assert forwarded.connect == 5.0
     assert forwarded.read == 30.0
     assert async_mock.call_args.kwargs["timeout"] == forwarded
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = _make_model()
+    assert llm.fireworks_api_base == "https://gateway.smith.langchain.com/fireworks"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,7 +1212,7 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
-        if self.openai_api_key is None:
+        if self.openai_api_key is None and _base_url_from_gateway:
             gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
             if gateway_api_key is not None:
                 self.openai_api_key = SecretStr(gateway_api_key)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,6 +1212,11 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
+        if self.openai_api_key is None:
+            gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            if gateway_api_key is not None:
+                self.openai_api_key = SecretStr(gateway_api_key)
+
         if self.openai_api_key is not None:
             # Because OpenAI and AsyncOpenAI clients support either sync or async
             # callables for the API key, we need to resolve separate values here.

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -179,6 +179,11 @@ def _get_ssrf_safe_client() -> httpx.Client:
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
 
 _LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/openai/v1"
+_LANGSMITH_GATEWAY_API_KEY_ENV_VARS = (
+    "LANGSMITH_GATEWAY_API_KEY",
+    "LANGSMITH_API_KEY",
+    "LANGCHAIN_API_KEY",
+)
 
 
 def _resolve_gateway_base_url() -> str | None:
@@ -188,6 +193,10 @@ def _resolve_gateway_base_url() -> str | None:
     if raw.lower() in ("true", "1", "yes"):
         return _LANGSMITH_GATEWAY_DEFAULT_URL
     return raw
+
+
+def _resolve_gateway_api_key() -> SecretStr | None:
+    return secret_from_env(_LANGSMITH_GATEWAY_API_KEY_ENV_VARS, default=None)()
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -1212,10 +1221,11 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
-        if self.openai_api_key is None and _base_url_from_gateway:
-            gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
+        explicit_api_key = bool({"api_key", "openai_api_key"} & self.model_fields_set)
+        if _base_url_from_gateway and not explicit_api_key:
+            gateway_api_key = _resolve_gateway_api_key()
             if gateway_api_key is not None:
-                self.openai_api_key = SecretStr(gateway_api_key)
+                self.openai_api_key = gateway_api_key
 
         if self.openai_api_key is not None:
             # Because OpenAI and AsyncOpenAI clients support either sync or async

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -178,6 +178,17 @@ def _get_ssrf_safe_client() -> httpx.Client:
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
 
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/openai/v1"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
     default = _MODEL_PROFILES.get(model_name) or {}
@@ -1167,26 +1178,33 @@ class BaseChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        self.openai_api_base = self.openai_api_base or os.getenv("OPENAI_API_BASE")
+        _gateway_base_url = _resolve_gateway_base_url()
+        _base_url_from_gateway = False
+        if self.openai_api_base is None:
+            if _gateway_base_url is not None:
+                self.openai_api_base = _gateway_base_url
+                _base_url_from_gateway = True
+            else:
+                self.openai_api_base = os.getenv("OPENAI_API_BASE")
 
-        # Enable stream_usage by default if using default base URL and client
-        if (
-            all(
-                getattr(self, key, None) is None
-                for key in (
-                    "stream_usage",
-                    "openai_proxy",
-                    "openai_api_base",
-                    "base_url",
-                    "client",
-                    "root_client",
-                    "async_client",
-                    "root_async_client",
-                    "http_client",
-                    "http_async_client",
-                )
+        # Enable stream_usage by default if using default base URL and client,
+        # or when the base URL was set by the LangSmith gateway (which proxies
+        # to OpenAI and supports streaming token usage).
+        if all(
+            getattr(self, key, None) is None
+            for key in (
+                "stream_usage",
+                "openai_proxy",
+                "client",
+                "root_client",
+                "async_client",
+                "root_async_client",
+                "http_client",
+                "http_async_client",
             )
-            and "OPENAI_BASE_URL" not in os.environ
+        ) and (
+            _base_url_from_gateway
+            or (self.openai_api_base is None and "OPENAI_BASE_URL" not in os.environ)
         ):
             self.stream_usage = True
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4505,18 +4505,18 @@ def test_defer_loading_in_responses_api_payload() -> None:
 
 def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
     assert llm.stream_usage is True
 
 
 def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
 
 
 def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4520,3 +4520,12 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4501,3 +4501,22 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
+    assert llm.stream_usage is True
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4531,6 +4531,50 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert llm.openai_api_key.get_secret_value() == "gateway-key"
 
 
+@pytest.mark.parametrize(
+    ("env_var", "expected"),
+    [
+        ("LANGSMITH_API_KEY", "langsmith-key"),
+        ("LANGCHAIN_API_KEY", "langchain-key"),
+    ],
+)
+def test_langsmith_gateway_api_key_langsmith_fallbacks(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, expected: str
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("LANGSMITH_API_KEY", raising=False)
+    monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv(env_var, expected)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == expected
+
+
+def test_langsmith_gateway_api_key_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("LANGSMITH_API_KEY", "langsmith-key")
+    monkeypatch.setenv("LANGCHAIN_API_KEY", "langchain-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-key")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_explicit_api_key_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="explicit-key")
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "explicit-key"
+
+
 def test_langsmith_gateway_api_key_not_used_without_gateway(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4529,3 +4529,14 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
     assert isinstance(llm.openai_api_key, SecretStr)
     assert llm.openai_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-key")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "provider-key"


### PR DESCRIPTION
## Description
When `LANGSMITH_GATEWAY` is enabled, OpenAI, Anthropic, and Fireworks chat models now resolve gateway auth from `LANGSMITH_GATEWAY_API_KEY`, `LANGSMITH_API_KEY`, then `LANGCHAIN_API_KEY`, while preserving explicit constructor keys.

## Release Note
LangSmith Gateway mode can authenticate with existing LangSmith API key environment variables.

## Test Plan
- [x] `langsmith_gateway` unit tests for OpenAI, Anthropic, and Fireworks

Made by [Open SWE](https://openswe.vercel.app/agents/fe21d869-3741-c4d9-c0ff-389ed6da5d9d)