### PR TITLE
feat(core): add shared gateway URL mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,12 +113,19 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .envrc
 .venv*
 venv*
 env/
 ENV/
 env.bak/
+
+# Credentials and certificates
+*.pem
+*.key
+*.crt
+credentials.json
 
 # Spyder project settings
 .spyderproject

--- a/libs/core/langchain_core/utils/gateway.py
+++ b/libs/core/langchain_core/utils/gateway.py
@@ -1,15 +1,11 @@
 """Shared configuration for LangSmith Gateway provider endpoints."""
 
-from __future__ import annotations
-
 import os
-from typing import TYPE_CHECKING, Final, Literal, TypedDict
+from collections.abc import Mapping
+from typing import Final, Literal, TypedDict
+from urllib.parse import urlsplit, urlunsplit
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from typing_extensions import NotRequired
-
+from typing_extensions import NotRequired
 
 GatewayProvider = Literal["anthropic", "fireworks", "google_genai", "openai"]
 
@@ -50,6 +46,16 @@ _DISABLED_GATEWAY_VALUES: Final = frozenset({"false", "0", "no"})
 _ENABLED_GATEWAY_VALUES: Final = frozenset({"true", "1", "yes"})
 
 
+def _append_gateway_provider_path(url: str, provider_path: str) -> str:
+    """Append a provider path without changing a URL's query or fragment."""
+    parsed_url = urlsplit(url)
+    if parsed_url.path.rstrip("/").endswith(provider_path):
+        return url
+    return urlunsplit(
+        parsed_url._replace(path=f"{parsed_url.path.rstrip('/')}{provider_path}")
+    )
+
+
 def resolve_langsmith_gateway_url(provider: GatewayProvider) -> str | None:
     """Resolve the configured LangSmith Gateway URL for a provider.
 
@@ -78,11 +84,6 @@ def resolve_langsmith_gateway_url(provider: GatewayProvider) -> str | None:
 
     provider_path = provider_config["path"]
     if raw_url.lower() not in _ENABLED_GATEWAY_VALUES:
-        if raw_url.rstrip("/").endswith(provider_path):
-            return raw_url
-        return f"{raw_url.rstrip('/')}{provider_path}"
+        return _append_gateway_provider_path(raw_url, provider_path)
 
-    gateway_url = LANGSMITH_GATEWAY_URL
-    if gateway_url.endswith(provider_path):
-        return gateway_url
-    return f"{gateway_url}{provider_path}"
+    return _append_gateway_provider_path(LANGSMITH_GATEWAY_URL, provider_path)

--- a/libs/core/langchain_core/utils/gateway.py
+++ b/libs/core/langchain_core/utils/gateway.py
@@ -2,10 +2,10 @@
 
 import os
 from collections.abc import Mapping
-from typing import Final, Literal, TypedDict
+from typing import Final, Literal
 from urllib.parse import urlsplit, urlunsplit
 
-from typing_extensions import NotRequired
+from typing_extensions import NotRequired, TypedDict
 
 GatewayProvider = Literal["anthropic", "fireworks", "google_genai", "openai"]
 

--- a/libs/core/langchain_core/utils/gateway.py
+++ b/libs/core/langchain_core/utils/gateway.py
@@ -1,0 +1,88 @@
+"""Shared configuration for LangSmith Gateway provider endpoints."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Final, Literal, TypedDict
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from typing_extensions import NotRequired
+
+
+GatewayProvider = Literal["anthropic", "fireworks", "google_genai", "openai"]
+
+
+class GatewayProviderConfig(TypedDict):
+    """LangSmith Gateway capabilities and URL path for a model provider."""
+
+    path: str
+    oauth: bool
+    static_key: bool
+    notes: NotRequired[str]
+
+
+LANGSMITH_GATEWAY_URL: Final = "https://gateway.smith.langchain.com"
+"""Default LangSmith Gateway root URL."""
+
+
+LANGSMITH_GATEWAY_PROVIDERS: Final[Mapping[GatewayProvider, GatewayProviderConfig]] = {
+    "anthropic": {"path": "/anthropic", "oauth": True, "static_key": True},
+    "fireworks": {"path": "/fireworks", "oauth": True, "static_key": True},
+    "google_genai": {
+        "path": "/google-genai",
+        "oauth": False,
+        "static_key": False,
+        "notes": "Not supported by LangSmith Gateway.",
+    },
+    "openai": {"path": "/openai/v1", "oauth": True, "static_key": True},
+}
+"""Initial LangSmith Gateway provider support matrix.
+
+Each entry declares the path appended to a Gateway root and whether the provider
+is available through OAuth or a static Gateway API key. `google_genai` is
+included to make its current unsupported status explicit.
+"""
+
+
+_DISABLED_GATEWAY_VALUES: Final = frozenset({"false", "0", "no"})
+_ENABLED_GATEWAY_VALUES: Final = frozenset({"true", "1", "yes"})
+
+
+def resolve_langsmith_gateway_url(provider: GatewayProvider) -> str | None:
+    """Resolve the configured LangSmith Gateway URL for a provider.
+
+    `LANGSMITH_GATEWAY=true` selects the hosted Gateway. A custom
+    `LANGSMITH_GATEWAY` value may be either a Gateway root URL, in which case
+    the provider path is appended, or a provider-qualified URL, which is used
+    unchanged. Disabled and unset values return `None`.
+
+    Args:
+        provider: Provider whose Gateway endpoint should be resolved.
+
+    Returns:
+        A provider-qualified Gateway URL, or `None` when Gateway is disabled.
+
+    Raises:
+        ValueError: If the provider is not supported by LangSmith Gateway.
+    """
+    raw_url = os.getenv("LANGSMITH_GATEWAY")
+    if raw_url is None or raw_url.lower() in _DISABLED_GATEWAY_VALUES:
+        return None
+
+    provider_config = LANGSMITH_GATEWAY_PROVIDERS[provider]
+    if not provider_config["oauth"] and not provider_config["static_key"]:
+        msg = f"LangSmith Gateway does not support provider `{provider}`."
+        raise ValueError(msg)
+
+    provider_path = provider_config["path"]
+    if raw_url.lower() not in _ENABLED_GATEWAY_VALUES:
+        if raw_url.rstrip("/").endswith(provider_path):
+            return raw_url
+        return f"{raw_url.rstrip('/')}{provider_path}"
+
+    gateway_url = LANGSMITH_GATEWAY_URL
+    if gateway_url.endswith(provider_path):
+        return gateway_url
+    return f"{gateway_url}{provider_path}"

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -1,0 +1,95 @@
+"""Tests for LangSmith Gateway URL configuration."""
+
+import pytest
+
+from langchain_core.utils.gateway import (
+    LANGSMITH_GATEWAY_PROVIDERS,
+    LANGSMITH_GATEWAY_URL,
+    resolve_langsmith_gateway_url,
+)
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_url"),
+    [
+        ("anthropic", f"{LANGSMITH_GATEWAY_URL}/anthropic"),
+        ("fireworks", f"{LANGSMITH_GATEWAY_URL}/fireworks"),
+        ("openai", f"{LANGSMITH_GATEWAY_URL}/openai/v1"),
+    ],
+)
+def test_resolve_langsmith_gateway_url_for_hosted_gateway(
+    monkeypatch: pytest.MonkeyPatch, provider: str, expected_url: str
+) -> None:
+    """A true value selects the hosted URL for every supported provider."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+
+    assert resolve_langsmith_gateway_url(provider) == expected_url  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_url"),
+    [
+        ("anthropic", "https://gateway.example.com/anthropic"),
+        ("fireworks", "https://gateway.example.com/fireworks"),
+        ("openai", "https://gateway.example.com/openai/v1"),
+    ],
+)
+def test_resolve_langsmith_gateway_url_for_custom_root(
+    monkeypatch: pytest.MonkeyPatch, provider: str, expected_url: str
+) -> None:
+    """A custom root gets the provider's centrally defined path."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "https://gateway.example.com/")
+
+    assert resolve_langsmith_gateway_url(provider) == expected_url  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("provider", "url"),
+    [
+        ("anthropic", "https://gateway.example.com/anthropic/"),
+        ("fireworks", "https://gateway.example.com/fireworks"),
+        ("openai", "https://gateway.example.com/openai/v1"),
+    ],
+)
+def test_resolve_langsmith_gateway_url_preserves_provider_url(
+    monkeypatch: pytest.MonkeyPatch, provider: str, url: str
+) -> None:
+    """A provider-qualified custom URL is not modified."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", url)
+
+    assert resolve_langsmith_gateway_url(provider) == url  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no"])
+def test_resolve_langsmith_gateway_url_disabled(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Disabled Gateway values leave provider configuration unchanged."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", value)
+
+    assert resolve_langsmith_gateway_url("openai") is None
+
+
+def test_resolve_langsmith_gateway_url_rejects_unsupported_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The published matrix makes Google GenAI's unsupported status explicit."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+
+    with pytest.raises(ValueError, match="does not support provider `google_genai`"):
+        resolve_langsmith_gateway_url("google_genai")
+
+
+def test_langsmith_gateway_provider_matrix() -> None:
+    """The initial support matrix is machine-consumable."""
+    assert LANGSMITH_GATEWAY_PROVIDERS == {
+        "anthropic": {"path": "/anthropic", "oauth": True, "static_key": True},
+        "fireworks": {"path": "/fireworks", "oauth": True, "static_key": True},
+        "google_genai": {
+            "path": "/google-genai",
+            "oauth": False,
+            "static_key": False,
+            "notes": "Not supported by LangSmith Gateway.",
+        },
+        "openai": {"path": "/openai/v1", "oauth": True, "static_key": True},
+    }

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -1,10 +1,13 @@
 """Tests for LangSmith Gateway URL configuration."""
 
+from typing import get_type_hints
+
 import pytest
 
 from langchain_core.utils.gateway import (
     LANGSMITH_GATEWAY_PROVIDERS,
     LANGSMITH_GATEWAY_URL,
+    GatewayProviderConfig,
     resolve_langsmith_gateway_url,
 )
 
@@ -93,3 +96,36 @@ def test_langsmith_gateway_provider_matrix() -> None:
         },
         "openai": {"path": "/openai/v1", "oauth": True, "static_key": True},
     }
+
+
+@pytest.mark.parametrize(
+    ("provider", "url", "expected_url"),
+    [
+        (
+            "openai",
+            "https://gateway.example.com?api-version=1#gateway",
+            "https://gateway.example.com/openai/v1?api-version=1#gateway",
+        ),
+        (
+            "openai",
+            "https://gateway.example.com/openai/v1?api-version=1#gateway",
+            "https://gateway.example.com/openai/v1?api-version=1#gateway",
+        ),
+    ],
+)
+def test_resolve_langsmith_gateway_url_preserves_query_and_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+    url: str,
+    expected_url: str,
+) -> None:
+    """Provider paths are added before URL query and fragment components."""
+    monkeypatch.setenv("LANGSMITH_GATEWAY", url)
+
+    assert resolve_langsmith_gateway_url(provider) == expected_url  # type: ignore[arg-type]
+
+
+def test_gateway_provider_config_runtime_type_metadata() -> None:
+    """The public provider configuration retains optional-key metadata at runtime."""
+    assert GatewayProviderConfig.__optional_keys__ == {"notes"}
+    assert get_type_hints(GatewayProviderConfig)["notes"] is str

--- a/libs/core/tests/unit_tests/utils/test_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_gateway.py
@@ -3,6 +3,7 @@
 from typing import get_type_hints
 
 import pytest
+from typing_extensions import NotRequired
 
 from langchain_core.utils.gateway import (
     LANGSMITH_GATEWAY_PROVIDERS,
@@ -128,4 +129,6 @@ def test_resolve_langsmith_gateway_url_preserves_query_and_fragment(
 def test_gateway_provider_config_runtime_type_metadata() -> None:
     """The public provider configuration retains optional-key metadata at runtime."""
     assert GatewayProviderConfig.__optional_keys__ == {"notes"}
-    assert get_type_hints(GatewayProviderConfig)["notes"] is str
+    assert get_type_hints(GatewayProviderConfig, include_extras=True)[
+        "notes"
+    ] == NotRequired[str]

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -974,9 +974,15 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env("ANTHROPIC_API_KEY", default=""),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
+        ),
     )
-    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided."""
+    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    """
 
     anthropic_proxy: str | None = Field(
         default_factory=from_env("ANTHROPIC_PROXY", default=None)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import hashlib
 import json
+import os
 import re
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
@@ -75,6 +76,18 @@ _message_type_lookups = {
 }
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/anthropic"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 _USER_AGENT: Final[str] = f"langchain-anthropic/{__version__}"
 
@@ -945,15 +958,18 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_url: str | None = Field(
         alias="base_url",
-        default_factory=from_env(
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env(
             ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
             default="https://api.anthropic.com",
-        ),
+        )(),
     )
     """Base URL for API requests. Only specify if using a proxy or service emulator.
 
     If a value isn't passed in, will attempt to read the value first from
     `ANTHROPIC_API_URL` and if that is not set, `ANTHROPIC_BASE_URL`.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over both env vars.
     """
 
     anthropic_api_key: SecretStr = Field(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -54,6 +54,7 @@ from langchain_core.utils.function_calling import (
     convert_to_json_schema,
     convert_to_openai_tool,
 )
+from langchain_core.utils.gateway import resolve_langsmith_gateway_url
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
@@ -76,18 +77,6 @@ _message_type_lookups = {
 }
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
-
-_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/anthropic"
-
-
-def _resolve_gateway_base_url() -> str | None:
-    raw = os.getenv("LANGSMITH_GATEWAY")
-    if raw is None or raw.lower() in ("false", "0", "no"):
-        return None
-    if raw.lower() in ("true", "1", "yes"):
-        return _LANGSMITH_GATEWAY_DEFAULT_URL
-    return raw
-
 
 _USER_AGENT: Final[str] = f"langchain-anthropic/{__version__}"
 
@@ -958,11 +947,13 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_url: str | None = Field(
         alias="base_url",
-        default_factory=lambda: _resolve_gateway_base_url()
-        or from_env(
-            ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
-            default="https://api.anthropic.com",
-        )(),
+        default_factory=lambda: (
+            resolve_langsmith_gateway_url("anthropic")
+            or from_env(
+                ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
+                default="https://api.anthropic.com",
+            )()
+        ),
     )
     """Base URL for API requests. Only specify if using a proxy or service emulator.
 
@@ -977,7 +968,7 @@ class ChatAnthropic(BaseChatModel):
         default_factory=lambda: SecretStr(
             (
                 os.getenv("LANGSMITH_GATEWAY_API_KEY")
-                if _resolve_gateway_base_url() is not None
+                if resolve_langsmith_gateway_url("anthropic") is not None
                 else None
             )
             or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -975,13 +975,17 @@ class ChatAnthropic(BaseChatModel):
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
         ),
     )
     """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     anthropic_proxy: str | None = Field(

--- a/libs/partners/anthropic/pyproject.toml
+++ b/libs/partners/anthropic/pyproject.toml
@@ -24,7 +24,7 @@ version = "1.4.8"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
     "anthropic>=0.96.0,<1.0.0",
-    "langchain-core>=1.4.7,<2.0.0",
+    "langchain-core>=1.4.10,<2.0.0",
     "pydantic>=2.7.4,<3.0.0",
 ]
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3574,3 +3574,27 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://gateway.smith.langchain.com/anthropic"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3606,3 +3606,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3598,3 +3598,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
     assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/anthropic/uv.lock
+++ b/libs/partners/anthropic/uv.lock
@@ -552,7 +552,7 @@ wheels = [
 
 [[package]]
 name = "langchain"
-version = "1.3.11"
+version = "1.3.12"
 source = { editable = "../../langchain_v1" }
 dependencies = [
     { name = "langchain-core" },
@@ -662,7 +662,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-lint = [{ name = "ruff", specifier = ">=0.13.1,<0.14.0" }]
+lint = [{ name = "ruff", specifier = ">=0.13.1,<0.16.0" }]
 test = [
     { name = "blockbuster", specifier = ">=1.5.5,<1.6" },
     { name = "defusedxml", specifier = ">=0.7.1,<1.0.0" },
@@ -689,7 +689,7 @@ typing = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.4.9"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
 from typing import (
@@ -107,6 +108,17 @@ logger = logging.getLogger(__name__)
 
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/fireworks"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -771,10 +783,14 @@ class ChatFireworks(BaseChatModel):
     """
 
     fireworks_api_base: str | None = Field(
-        alias="base_url", default_factory=from_env("FIREWORKS_API_BASE", default=None)
+        alias="base_url",
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env("FIREWORKS_API_BASE", default=None)(),
     )
     """Base URL path for API requests, leave blank if not using a proxy or service
     emulator.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over `FIREWORKS_API_BASE`.
     """
 
     request_timeout: float | tuple[float, float] | Any | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -88,6 +88,7 @@ from langchain_core.utils.function_calling import (
     convert_to_json_schema,
     convert_to_openai_tool,
 )
+from langchain_core.utils.gateway import resolve_langsmith_gateway_url
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs, from_env, secret_from_env
 from pydantic import (
@@ -108,17 +109,6 @@ logger = logging.getLogger(__name__)
 
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
-
-_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/fireworks"
-
-
-def _resolve_gateway_base_url() -> str | None:
-    raw = os.getenv("LANGSMITH_GATEWAY")
-    if raw is None or raw.lower() in ("false", "0", "no"):
-        return None
-    if raw.lower() in ("true", "1", "yes"):
-        return _LANGSMITH_GATEWAY_DEFAULT_URL
-    return raw
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -771,7 +761,7 @@ class ChatFireworks(BaseChatModel):
         default_factory=lambda: SecretStr(
             (
                 os.getenv("LANGSMITH_GATEWAY_API_KEY")
-                if _resolve_gateway_base_url() is not None
+                if resolve_langsmith_gateway_url("fireworks") is not None
                 else None
             )
             or secret_from_env(
@@ -793,8 +783,10 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_base: str | None = Field(
         alias="base_url",
-        default_factory=lambda: _resolve_gateway_base_url()
-        or from_env("FIREWORKS_API_BASE", default=None)(),
+        default_factory=lambda: (
+            resolve_langsmith_gateway_url("fireworks")
+            or from_env("FIREWORKS_API_BASE", default=None)()
+        ),
     )
     """Base URL path for API requests, leave blank if not using a proxy or service
     emulator.

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -769,7 +769,11 @@ class ChatFireworks(BaseChatModel):
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env(
                 "FIREWORKS_API_KEY",
                 error_message=(
@@ -784,7 +788,7 @@ class ChatFireworks(BaseChatModel):
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -768,18 +768,23 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            "FIREWORKS_API_KEY",
-            error_message=(
-                "You must specify an api key. "
-                "You can pass it an argument as `api_key=...` or "
-                "set the environment variable `FIREWORKS_API_KEY`."
-            ),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env(
+                "FIREWORKS_API_KEY",
+                error_message=(
+                    "You must specify an api key. "
+                    "You can pass it an argument as `api_key=...` or "
+                    "set the environment variable `FIREWORKS_API_KEY`."
+                ),
+            )().get_secret_value()
         ),
     )
     """Fireworks API key.
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/pyproject.toml
+++ b/libs/partners/fireworks/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.4.3"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.7,<2.0.0",
+    "langchain-core>=1.4.10,<2.0.0",
     "fireworks-ai>=1.2.0a71,<2.0.0",
     "openai>=2.0.0,<3.0.0",
     "requests>=2.0.0,<3.0.0",

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1619,3 +1619,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
     llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
     assert llm.fireworks_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "provider-key")
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1611,3 +1611,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
     llm = _make_model()
     assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1591,3 +1591,23 @@ def test_request_timeout_tuple_normalized_to_httpx_timeout(
     assert forwarded.connect == 5.0
     assert forwarded.read == 30.0
     assert async_mock.call_args.kwargs["timeout"] == forwarded
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = _make_model()
+    assert llm.fireworks_api_base == "https://gateway.smith.langchain.com/fireworks"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None

--- a/libs/partners/fireworks/uv.lock
+++ b/libs/partners/fireworks/uv.lock
@@ -737,7 +737,7 @@ wheels = [
 
 [[package]]
 name = "langchain-core"
-version = "1.4.8"
+version = "1.4.9"
 source = { editable = "../../core" }
 dependencies = [
     { name = "jsonpatch" },

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,7 +1212,7 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
-        if self.openai_api_key is None:
+        if self.openai_api_key is None and _base_url_from_gateway:
             gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
             if gateway_api_key is not None:
                 self.openai_api_key = SecretStr(gateway_api_key)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -112,6 +112,7 @@ from langchain_core.utils.function_calling import (
     convert_to_openai_function,
     convert_to_openai_tool,
 )
+from langchain_core.utils.gateway import resolve_langsmith_gateway_url
 from langchain_core.utils.pydantic import (
     PydanticBaseModel,
     TypeBaseModel,
@@ -177,17 +178,6 @@ def _get_ssrf_safe_client() -> httpx.Client:
 
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
-
-_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/openai/v1"
-
-
-def _resolve_gateway_base_url() -> str | None:
-    raw = os.getenv("LANGSMITH_GATEWAY")
-    if raw is None or raw.lower() in ("false", "0", "no"):
-        return None
-    if raw.lower() in ("true", "1", "yes"):
-        return _LANGSMITH_GATEWAY_DEFAULT_URL
-    return raw
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -1178,7 +1168,7 @@ class BaseChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        _gateway_base_url = _resolve_gateway_base_url()
+        _gateway_base_url = resolve_langsmith_gateway_url("openai")
         _base_url_from_gateway = False
         if self.openai_api_base is None:
             if _gateway_base_url is not None:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,6 +1212,11 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
+        if self.openai_api_key is None:
+            gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            if gateway_api_key is not None:
+                self.openai_api_key = SecretStr(gateway_api_key)
+
         if self.openai_api_key is not None:
             # Because OpenAI and AsyncOpenAI clients support either sync or async
             # callables for the API key, we need to resolve separate values here.

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -178,6 +178,17 @@ def _get_ssrf_safe_client() -> httpx.Client:
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
 
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/openai/v1"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
     default = _MODEL_PROFILES.get(model_name) or {}
@@ -1167,26 +1178,33 @@ class BaseChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        self.openai_api_base = self.openai_api_base or os.getenv("OPENAI_API_BASE")
+        _gateway_base_url = _resolve_gateway_base_url()
+        _base_url_from_gateway = False
+        if self.openai_api_base is None:
+            if _gateway_base_url is not None:
+                self.openai_api_base = _gateway_base_url
+                _base_url_from_gateway = True
+            else:
+                self.openai_api_base = os.getenv("OPENAI_API_BASE")
 
-        # Enable stream_usage by default if using default base URL and client
-        if (
-            all(
-                getattr(self, key, None) is None
-                for key in (
-                    "stream_usage",
-                    "openai_proxy",
-                    "openai_api_base",
-                    "base_url",
-                    "client",
-                    "root_client",
-                    "async_client",
-                    "root_async_client",
-                    "http_client",
-                    "http_async_client",
-                )
+        # Enable stream_usage by default if using default base URL and client,
+        # or when the base URL was set by the LangSmith gateway (which proxies
+        # to OpenAI and supports streaming token usage).
+        if all(
+            getattr(self, key, None) is None
+            for key in (
+                "stream_usage",
+                "openai_proxy",
+                "client",
+                "root_client",
+                "async_client",
+                "root_async_client",
+                "http_client",
+                "http_async_client",
             )
-            and "OPENAI_BASE_URL" not in os.environ
+        ) and (
+            _base_url_from_gateway
+            or (self.openai_api_base is None and "OPENAI_BASE_URL" not in os.environ)
         ):
             self.stream_usage = True
 

--- a/libs/partners/openai/pyproject.toml
+++ b/libs/partners/openai/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 version = "1.3.4"
 requires-python = ">=3.10.0,<4.0.0"
 dependencies = [
-    "langchain-core>=1.4.9,<2.0.0",
+    "langchain-core>=1.4.10,<2.0.0",
     "openai>=2.26.0,<3.0.0",
     "tiktoken>=0.7.0,<1.0.0",
 ]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4505,18 +4505,18 @@ def test_defer_loading_in_responses_api_payload() -> None:
 
 def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
     assert llm.stream_usage is True
 
 
 def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
 
 
 def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4520,3 +4520,12 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4501,3 +4501,22 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
+    assert llm.stream_usage is True
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4529,3 +4529,14 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
     assert isinstance(llm.openai_api_key, SecretStr)
     assert llm.openai_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-key")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "provider-key"


### PR DESCRIPTION
A configured gateway root can now be resolved consistently for each supported provider, while provider-qualified URLs continue to work unchanged. This gives integrations and downstream consumers one central support matrix instead of duplicating provider-specific paths.

The mapping currently supports OpenAI, Anthropic, and Fireworks for OAuth and static-key modes. Google GenAI is represented explicitly as unsupported.

## Release note

Gateway configuration now accepts either a root URL or a provider-qualified URL for OpenAI, Anthropic, and Fireworks.

Tests cover hosted, custom-root, provider-qualified, disabled, and unsupported-provider behavior.

AI assistance was used in preparing this contribution.