### PR TITLE
feat(core): add gateway OAuth bearer authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,10 @@ celerybeat.pid
 # Environments
 .env
 .envrc
+*.pem
+*.key
+*.crt
+credentials.json
 .venv*
 venv*
 env/

--- a/libs/core/langchain_core/utils/__init__.py
+++ b/libs/core/langchain_core/utils/__init__.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
         print_text,
     )
     from langchain_core.utils.iter import batch_iterate
+    from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
     from langchain_core.utils.pydantic import pre_init
     from langchain_core.utils.strings import (
         comma_list,
@@ -42,6 +43,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = (
+    "LangSmithGatewayOAuth",
     "StrictFormatter",
     "abatch_iterate",
     "batch_iterate",
@@ -72,6 +74,7 @@ __all__ = (
 
 _dynamic_imports = {
     "image": "__module__",
+    "LangSmithGatewayOAuth": "langsmith_gateway",
     "abatch_iterate": "aiter",
     "get_from_dict_or_env": "env",
     "get_from_env": "env",

--- a/libs/core/langchain_core/utils/langsmith_gateway.py
+++ b/libs/core/langchain_core/utils/langsmith_gateway.py
@@ -1,0 +1,44 @@
+"""Authentication helpers for LangSmith Gateway clients."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Generator
+
+
+class LangSmithGatewayOAuth(httpx.Auth):
+    """Apply a LangSmith OAuth token to requests sent through Gateway.
+
+    Gateway removes this credential before forwarding the request to the selected
+    provider. The adapter therefore removes provider credential headers before
+    setting the Gateway-specific bearer token.
+
+    Args:
+        token: LangSmith OAuth access token.
+    """
+
+    def __init__(self, token: str) -> None:
+        """Initialize the auth adapter with a LangSmith OAuth access token."""
+        self._token = token
+
+    def _authorize(self, request: httpx.Request) -> httpx.Request:
+        request.headers.pop("Authorization", None)
+        request.headers.pop("X-Api-Key", None)
+        request.headers["Authorization"] = f"Bearer {self._token}"
+        return request
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        """Add the bearer token to a synchronous request."""
+        yield self._authorize(request)
+
+    async def async_auth_flow(
+        self, request: httpx.Request
+    ) -> AsyncGenerator[httpx.Request, httpx.Response]:
+        """Add the bearer token to an asynchronous request."""
+        yield self._authorize(request)

--- a/libs/core/tests/unit_tests/utils/test_imports.py
+++ b/libs/core/tests/unit_tests/utils/test_imports.py
@@ -1,6 +1,7 @@
 from langchain_core.utils import __all__
 
 EXPECTED_ALL = [
+    "LangSmithGatewayOAuth",
     "StrictFormatter",
     "check_package_version",
     "convert_to_secret_str",

--- a/libs/core/tests/unit_tests/utils/test_langsmith_gateway.py
+++ b/libs/core/tests/unit_tests/utils/test_langsmith_gateway.py
@@ -1,0 +1,21 @@
+import httpx
+
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
+
+
+def test_gateway_oauth_replaces_provider_auth_headers() -> None:
+    """Gateway OAuth must not be forwarded as a provider credential."""
+    auth = LangSmithGatewayOAuth("oauth-token")
+    request = httpx.Request(
+        "POST",
+        "https://gateway.smith.langchain.com/anthropic/v1/messages",
+        headers={
+            "Authorization": "Bearer provider-key",
+            "X-Api-Key": "provider-key",
+        },
+    )
+
+    authorized_request = next(auth.auth_flow(request))
+
+    assert authorized_request.headers["Authorization"] == "Bearer oauth-token"
+    assert "X-Api-Key" not in authorized_request.headers

--- a/libs/partners/anthropic/langchain_anthropic/_client_utils.py
+++ b/libs/partners/anthropic/langchain_anthropic/_client_utils.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from typing import Any
 
 import anthropic
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 
 _NOT_GIVEN: Any = object()
 
@@ -49,6 +50,7 @@ def _get_default_httpx_client(
     base_url: str | None,
     timeout: Any = _NOT_GIVEN,
     anthropic_proxy: str | None = None,
+    auth: LangSmithGatewayOAuth | None = None,
 ) -> _SyncHttpxClientWrapper:
     kwargs: dict[str, Any] = {
         "base_url": base_url
@@ -59,6 +61,8 @@ def _get_default_httpx_client(
         kwargs["timeout"] = timeout
     if anthropic_proxy is not None:
         kwargs["proxy"] = anthropic_proxy
+    if auth is not None:
+        kwargs["auth"] = auth
     return _SyncHttpxClientWrapper(**kwargs)
 
 
@@ -68,6 +72,7 @@ def _get_default_async_httpx_client(
     base_url: str | None,
     timeout: Any = _NOT_GIVEN,
     anthropic_proxy: str | None = None,
+    auth: LangSmithGatewayOAuth | None = None,
 ) -> _AsyncHttpxClientWrapper:
     kwargs: dict[str, Any] = {
         "base_url": base_url
@@ -78,4 +83,6 @@ def _get_default_async_httpx_client(
         kwargs["timeout"] = timeout
     if anthropic_proxy is not None:
         kwargs["proxy"] = anthropic_proxy
+    if auth is not None:
+        kwargs["auth"] = auth
     return _AsyncHttpxClientWrapper(**kwargs)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -974,9 +974,15 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env("ANTHROPIC_API_KEY", default=""),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
+        ),
     )
-    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided."""
+    """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    """
 
     anthropic_proxy: str | None = Field(
         default_factory=from_env("ANTHROPIC_PROXY", default=None)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -959,11 +959,13 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_url: str | None = Field(
         alias="base_url",
-        default_factory=lambda: _resolve_gateway_base_url()
-        or from_env(
-            ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
-            default="https://api.anthropic.com",
-        )(),
+        default_factory=lambda: (
+            _resolve_gateway_base_url()
+            or from_env(
+                ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
+                default="https://api.anthropic.com",
+            )()
+        ),
     )
     """Base URL for API requests. Only specify if using a proxy or service emulator.
 
@@ -979,6 +981,12 @@ class ChatAnthropic(BaseChatModel):
             (
                 os.getenv("LANGSMITH_GATEWAY_API_KEY")
                 if _resolve_gateway_base_url() is not None
+                else None
+            )
+            or (
+                "langsmith-gateway-oauth"
+                if _resolve_gateway_base_url() is not None
+                and os.getenv("LANGSMITH_GATEWAY_OAUTH_TOKEN") is not None
                 else None
             )
             or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
@@ -1242,7 +1250,10 @@ class ChatAnthropic(BaseChatModel):
 
     @property
     def _gateway_oauth_auth(self) -> LangSmithGatewayOAuth | None:
-        if self.langsmith_gateway_oauth_token is None:
+        if (
+            self.langsmith_gateway_oauth_token is None
+            or self.anthropic_api_url != _resolve_gateway_base_url()
+        ):
             return None
         return LangSmithGatewayOAuth(
             self.langsmith_gateway_oauth_token.get_secret_value()

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -54,6 +54,7 @@ from langchain_core.utils.function_calling import (
     convert_to_json_schema,
     convert_to_openai_tool,
 )
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs
 from pydantic import BaseModel, ConfigDict, Field, SecretStr, model_validator
@@ -1000,6 +1001,16 @@ class ChatAnthropic(BaseChatModel):
     default_headers: Mapping[str, str] | None = None
     """Headers to pass to the Anthropic clients, will be used for every API call."""
 
+    langsmith_gateway_oauth_token: SecretStr | None = Field(
+        default_factory=secret_from_env("LANGSMITH_GATEWAY_OAUTH_TOKEN", default=None),
+        exclude=True,
+    )
+    """OAuth token used to authenticate this client to LangSmith Gateway.
+
+    When set, the token is sent as an `Authorization` bearer credential and is
+    never passed to Anthropic as an API key.
+    """
+
     betas: list[str] | None = None
     """List of beta features to enable. If specified, invocations will be routed
     through `client.beta.messages.create`.
@@ -1229,6 +1240,14 @@ class ChatAnthropic(BaseChatModel):
 
         return client_params
 
+    @property
+    def _gateway_oauth_auth(self) -> LangSmithGatewayOAuth | None:
+        if self.langsmith_gateway_oauth_token is None:
+            return None
+        return LangSmithGatewayOAuth(
+            self.langsmith_gateway_oauth_token.get_secret_value()
+        )
+
     @cached_property
     def _client(self) -> anthropic.Client:
         client_params = self._client_params
@@ -1237,6 +1256,8 @@ class ChatAnthropic(BaseChatModel):
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
             http_client_params["anthropic_proxy"] = self.anthropic_proxy
+        if (auth := self._gateway_oauth_auth) is not None:
+            http_client_params["auth"] = auth
         http_client = _get_default_httpx_client(**http_client_params)
         params = {
             **client_params,
@@ -1252,6 +1273,8 @@ class ChatAnthropic(BaseChatModel):
             http_client_params["timeout"] = client_params["timeout"]
         if self.anthropic_proxy:
             http_client_params["anthropic_proxy"] = self.anthropic_proxy
+        if (auth := self._gateway_oauth_auth) is not None:
+            http_client_params["auth"] = auth
         http_client = _get_default_async_httpx_client(**http_client_params)
         params = {
             **client_params,

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -6,6 +6,7 @@ import copy
 import datetime
 import hashlib
 import json
+import os
 import re
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
@@ -75,6 +76,18 @@ _message_type_lookups = {
 }
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/anthropic"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 _USER_AGENT: Final[str] = f"langchain-anthropic/{__version__}"
 
@@ -945,15 +958,18 @@ class ChatAnthropic(BaseChatModel):
 
     anthropic_api_url: str | None = Field(
         alias="base_url",
-        default_factory=from_env(
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env(
             ["ANTHROPIC_API_URL", "ANTHROPIC_BASE_URL"],
             default="https://api.anthropic.com",
-        ),
+        )(),
     )
     """Base URL for API requests. Only specify if using a proxy or service emulator.
 
     If a value isn't passed in, will attempt to read the value first from
     `ANTHROPIC_API_URL` and if that is not set, `ANTHROPIC_BASE_URL`.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over both env vars.
     """
 
     anthropic_api_key: SecretStr = Field(

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -975,13 +975,17 @@ class ChatAnthropic(BaseChatModel):
     anthropic_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env("ANTHROPIC_API_KEY", default="")().get_secret_value()
         ),
     )
     """Automatically read from env var `ANTHROPIC_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     anthropic_proxy: str | None = Field(

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3616,3 +3616,32 @@ def test_langsmith_gateway_api_key_not_used_without_gateway(
     monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_key.get_secret_value() == "provider-key"
+
+
+def test_langsmith_gateway_oauth_uses_placeholder_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    assert llm.anthropic_api_key.get_secret_value() == "langsmith-gateway-oauth"
+    assert llm._gateway_oauth_auth is not None
+
+
+def test_langsmith_gateway_oauth_is_not_used_for_custom_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+
+    llm = ChatAnthropic(
+        model=MODEL_NAME,
+        api_key="provider-key",
+        base_url="https://api.anthropic.com",
+    )
+
+    assert llm._gateway_oauth_auth is None

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3574,3 +3574,27 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://gateway.smith.langchain.com/anthropic"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
+    assert llm.anthropic_api_url == "https://api.anthropic.com"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3606,3 +3606,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME)
     assert llm.anthropic_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "provider-key")
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3598,3 +3598,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
     llm = ChatAnthropic(model=MODEL_NAME, api_key="test")
     assert llm.anthropic_api_url == "https://api.anthropic.com"
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    llm = ChatAnthropic(model=MODEL_NAME)
+    assert llm.anthropic_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+import os
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
 from typing import (
@@ -107,6 +108,17 @@ logger = logging.getLogger(__name__)
 
 
 _MODEL_PROFILES = cast("ModelProfileRegistry", _PROFILES)
+
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/fireworks"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
 
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
@@ -771,10 +783,14 @@ class ChatFireworks(BaseChatModel):
     """
 
     fireworks_api_base: str | None = Field(
-        alias="base_url", default_factory=from_env("FIREWORKS_API_BASE", default=None)
+        alias="base_url",
+        default_factory=lambda: _resolve_gateway_base_url()
+        or from_env("FIREWORKS_API_BASE", default=None)(),
     )
     """Base URL path for API requests, leave blank if not using a proxy or service
     emulator.
+
+    If `LANGSMITH_GATEWAY` is set, it takes precedence over `FIREWORKS_API_BASE`.
     """
 
     request_timeout: float | tuple[float, float] | Any | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -769,7 +769,11 @@ class ChatFireworks(BaseChatModel):
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
         default_factory=lambda: SecretStr(
-            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            (
+                os.getenv("LANGSMITH_GATEWAY_API_KEY")
+                if _resolve_gateway_base_url() is not None
+                else None
+            )
             or secret_from_env(
                 "FIREWORKS_API_KEY",
                 error_message=(
@@ -784,7 +788,7 @@ class ChatFireworks(BaseChatModel):
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
 
-    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
+    If `LANGSMITH_GATEWAY` is enabled, `LANGSMITH_GATEWAY_API_KEY` takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -775,6 +775,12 @@ class ChatFireworks(BaseChatModel):
                 if _resolve_gateway_base_url() is not None
                 else None
             )
+            or (
+                "langsmith-gateway-oauth"
+                if _resolve_gateway_base_url() is not None
+                and os.getenv("LANGSMITH_GATEWAY_OAUTH_TOKEN") is not None
+                else None
+            )
             or secret_from_env(
                 "FIREWORKS_API_KEY",
                 error_message=(
@@ -794,8 +800,10 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_base: str | None = Field(
         alias="base_url",
-        default_factory=lambda: _resolve_gateway_base_url()
-        or from_env("FIREWORKS_API_BASE", default=None)(),
+        default_factory=lambda: (
+            _resolve_gateway_base_url()
+            or from_env("FIREWORKS_API_BASE", default=None)()
+        ),
     )
     """Base URL path for API requests, leave blank if not using a proxy or service
     emulator.
@@ -913,11 +921,7 @@ class ChatFireworks(BaseChatModel):
         # so the LangChain `run_manager` sees each attempt. Suppress the
         # SDK's built-in retry layer to avoid double-retrying.
         if not self.client:
-            http_client = (
-                httpx.Client(auth=LangSmithGatewayOAuth(token.get_secret_value()))
-                if (token := self.langsmith_gateway_oauth_token) is not None
-                else None
-            )
+            http_client = self._gateway_oauth_http_client()
             self._sdk_client = Fireworks(
                 api_key=api_key,
                 base_url=base_url,
@@ -927,11 +931,7 @@ class ChatFireworks(BaseChatModel):
             )
             self.client = self._sdk_client.chat.completions
         if not self.async_client:
-            http_async_client = (
-                httpx.AsyncClient(auth=LangSmithGatewayOAuth(token.get_secret_value()))
-                if (token := self.langsmith_gateway_oauth_token) is not None
-                else None
-            )
+            http_async_client = self._gateway_oauth_async_http_client()
             self._async_sdk_client = AsyncFireworks(
                 api_key=api_key,
                 base_url=base_url,
@@ -941,6 +941,36 @@ class ChatFireworks(BaseChatModel):
             )
             self.async_client = self._async_sdk_client.chat.completions
         return self
+
+    def _is_langsmith_gateway(self) -> bool:
+        """Return whether this instance is configured to use LangSmith Gateway."""
+        return self.fireworks_api_base == _resolve_gateway_base_url()
+
+    def _gateway_oauth_http_client(self) -> httpx.Client | None:
+        """Build a synchronous OAuth client when Gateway OAuth is enabled."""
+        if (
+            self.langsmith_gateway_oauth_token is None
+            or not self._is_langsmith_gateway()
+        ):
+            return None
+        return httpx.Client(
+            auth=LangSmithGatewayOAuth(
+                self.langsmith_gateway_oauth_token.get_secret_value()
+            )
+        )
+
+    def _gateway_oauth_async_http_client(self) -> httpx.AsyncClient | None:
+        """Build an asynchronous OAuth client when Gateway OAuth is enabled."""
+        if (
+            self.langsmith_gateway_oauth_token is None
+            or not self._is_langsmith_gateway()
+        ):
+            return None
+        return httpx.AsyncClient(
+            auth=LangSmithGatewayOAuth(
+                self.langsmith_gateway_oauth_token.get_secret_value()
+            )
+        )
 
     def close(self) -> None:
         """Close the underlying sync HTTP client.

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -768,18 +768,23 @@ class ChatFireworks(BaseChatModel):
 
     fireworks_api_key: SecretStr = Field(
         alias="api_key",
-        default_factory=secret_from_env(
-            "FIREWORKS_API_KEY",
-            error_message=(
-                "You must specify an api key. "
-                "You can pass it an argument as `api_key=...` or "
-                "set the environment variable `FIREWORKS_API_KEY`."
-            ),
+        default_factory=lambda: SecretStr(
+            os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            or secret_from_env(
+                "FIREWORKS_API_KEY",
+                error_message=(
+                    "You must specify an api key. "
+                    "You can pass it an argument as `api_key=...` or "
+                    "set the environment variable `FIREWORKS_API_KEY`."
+                ),
+            )().get_secret_value()
         ),
     )
     """Fireworks API key.
 
     Automatically read from env variable `FIREWORKS_API_KEY` if not provided.
+
+    If `LANGSMITH_GATEWAY_API_KEY` is set, it takes precedence.
     """
 
     fireworks_api_base: str | None = Field(

--- a/libs/partners/fireworks/langchain_fireworks/chat_models.py
+++ b/libs/partners/fireworks/langchain_fireworks/chat_models.py
@@ -88,6 +88,7 @@ from langchain_core.utils.function_calling import (
     convert_to_json_schema,
     convert_to_openai_tool,
 )
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 from langchain_core.utils.pydantic import is_basemodel_subclass
 from langchain_core.utils.utils import _build_model_kwargs, from_env, secret_from_env
 from pydantic import (
@@ -802,6 +803,16 @@ class ChatFireworks(BaseChatModel):
     If `LANGSMITH_GATEWAY` is set, it takes precedence over `FIREWORKS_API_BASE`.
     """
 
+    langsmith_gateway_oauth_token: SecretStr | None = Field(
+        default_factory=secret_from_env("LANGSMITH_GATEWAY_OAUTH_TOKEN", default=None),
+        exclude=True,
+    )
+    """OAuth token used to authenticate this client to LangSmith Gateway.
+
+    When set, the token is sent as an `Authorization` bearer credential and is
+    never passed to Fireworks as an API key.
+    """
+
     request_timeout: float | tuple[float, float] | Any | None = Field(
         default=None, alias="timeout"
     )
@@ -902,19 +913,31 @@ class ChatFireworks(BaseChatModel):
         # so the LangChain `run_manager` sees each attempt. Suppress the
         # SDK's built-in retry layer to avoid double-retrying.
         if not self.client:
+            http_client = (
+                httpx.Client(auth=LangSmithGatewayOAuth(token.get_secret_value()))
+                if (token := self.langsmith_gateway_oauth_token) is not None
+                else None
+            )
             self._sdk_client = Fireworks(
                 api_key=api_key,
                 base_url=base_url,
                 timeout=timeout,
                 max_retries=0,
+                http_client=http_client,
             )
             self.client = self._sdk_client.chat.completions
         if not self.async_client:
+            http_async_client = (
+                httpx.AsyncClient(auth=LangSmithGatewayOAuth(token.get_secret_value()))
+                if (token := self.langsmith_gateway_oauth_token) is not None
+                else None
+            )
             self._async_sdk_client = AsyncFireworks(
                 api_key=api_key,
                 base_url=base_url,
                 timeout=timeout,
                 max_retries=0,
+                http_client=http_async_client,
             )
             self.async_client = self._async_sdk_client.chat.completions
         return self

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1619,3 +1619,13 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
     llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
     assert llm.fireworks_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("FIREWORKS_API_KEY", "provider-key")
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1629,3 +1629,36 @@ def test_langsmith_gateway_api_key_not_used_without_gateway(
     monkeypatch.setenv("FIREWORKS_API_KEY", "provider-key")
     llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
     assert llm.fireworks_api_key.get_secret_value() == "provider-key"
+
+
+def test_langsmith_gateway_oauth_uses_placeholder_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+
+    assert llm.fireworks_api_key.get_secret_value() == "langsmith-gateway-oauth"
+    oauth_client = llm._gateway_oauth_http_client()
+    assert oauth_client is not None
+    oauth_client.close()
+    llm.close()
+
+
+def test_langsmith_gateway_oauth_is_not_used_for_custom_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+
+    llm = ChatFireworks(
+        model=MODEL_NAME,
+        api_key="provider-key",  # type: ignore[arg-type]
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert llm._gateway_oauth_http_client() is None
+    llm.close()

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1611,3 +1611,11 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
     llm = _make_model()
     assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    llm = ChatFireworks(model=MODEL_NAME)  # type: ignore[call-arg]
+    assert llm.fireworks_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/fireworks/tests/unit_tests/test_chat_models.py
@@ -1591,3 +1591,23 @@ def test_request_timeout_tuple_normalized_to_httpx_timeout(
     assert forwarded.connect == 5.0
     assert forwarded.read == 30.0
     assert async_mock.call_args.kwargs["timeout"] == forwarded
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = _make_model()
+    assert llm.fireworks_api_base == "https://gateway.smith.langchain.com/fireworks"
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.delenv("FIREWORKS_API_BASE", raising=False)
+    llm = _make_model()
+    assert llm.fireworks_api_base is None

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -507,12 +507,14 @@ def _get_default_httpx_client(
     Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
     """
     if auth is not None:
-        return _SyncHttpxClientWrapper(
-            base_url=base_url,
-            timeout=timeout,
-            transport=httpx.HTTPTransport(socket_options=socket_options),
-            auth=auth,
-        )
+        kwargs: dict[str, Any] = {
+            "base_url": base_url,
+            "timeout": timeout,
+            "auth": auth,
+        }
+        if socket_options:
+            kwargs["transport"] = httpx.HTTPTransport(socket_options=socket_options)
+        return _SyncHttpxClientWrapper(**kwargs)
     try:
         hash(timeout)
     except TypeError:
@@ -532,12 +534,16 @@ def _get_default_async_httpx_client(
     Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
     """
     if auth is not None:
-        return _AsyncHttpxClientWrapper(
-            base_url=base_url,
-            timeout=timeout,
-            transport=httpx.AsyncHTTPTransport(socket_options=socket_options),
-            auth=auth,
-        )
+        kwargs: dict[str, Any] = {
+            "base_url": base_url,
+            "timeout": timeout,
+            "auth": auth,
+        }
+        if socket_options:
+            kwargs["transport"] = httpx.AsyncHTTPTransport(
+                socket_options=socket_options
+            )
+        return _AsyncHttpxClientWrapper(**kwargs)
     try:
         hash(timeout)
     except TypeError:

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -24,6 +24,7 @@ from typing import Any, TypeVar, cast
 
 import httpx
 import openai
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 from pydantic import SecretStr
 
 logger = logging.getLogger(__name__)
@@ -499,11 +500,19 @@ def _get_default_httpx_client(
     base_url: str | None,
     timeout: Any,
     socket_options: tuple[SocketOption, ...] = (),
+    auth: LangSmithGatewayOAuth | None = None,
 ) -> _SyncHttpxClientWrapper:
     """Get default httpx client.
 
     Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
     """
+    if auth is not None:
+        return _SyncHttpxClientWrapper(
+            base_url=base_url,
+            timeout=timeout,
+            transport=httpx.HTTPTransport(socket_options=socket_options),
+            auth=auth,
+        )
     try:
         hash(timeout)
     except TypeError:
@@ -516,11 +525,19 @@ def _get_default_async_httpx_client(
     base_url: str | None,
     timeout: Any,
     socket_options: tuple[SocketOption, ...] = (),
+    auth: LangSmithGatewayOAuth | None = None,
 ) -> _AsyncHttpxClientWrapper:
     """Get default httpx client.
 
     Uses cached client unless timeout is `httpx.Timeout`, which is not hashable.
     """
+    if auth is not None:
+        return _AsyncHttpxClientWrapper(
+            base_url=base_url,
+            timeout=timeout,
+            transport=httpx.AsyncHTTPTransport(socket_options=socket_options),
+            auth=auth,
+        )
     try:
         hash(timeout)
     except TypeError:

--- a/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_client_utils.py
@@ -430,6 +430,7 @@ def _build_proxied_sync_httpx_client(
     proxy: str,
     verify: Any,
     socket_options: tuple[SocketOption, ...] = (),
+    auth: httpx.Auth | None = None,
 ) -> httpx.Client:
     """httpx.Client for the openai_proxy code path.
 
@@ -437,7 +438,7 @@ def _build_proxied_sync_httpx_client(
     `httpx.Client(proxy=..., verify=...)` with no transport injected.
     """
     if not socket_options:
-        return httpx.Client(proxy=proxy, verify=verify)
+        return httpx.Client(proxy=proxy, verify=verify, auth=auth)
     # Mount under `all://` (not `transport=`) so `Client._mounts` mirrors the
     # shape produced by httpx's own `proxy=` path — a single-entry dict keyed
     # by `URLPattern("all://")`. Callers (and the existing proxy integration
@@ -453,13 +454,14 @@ def _build_proxied_sync_httpx_client(
         socket_options=list(socket_options),
         limits=_DEFAULT_CONNECTION_LIMITS,
     )
-    return httpx.Client(mounts={"all://": transport})
+    return httpx.Client(mounts={"all://": transport}, auth=auth)
 
 
 def _build_proxied_async_httpx_client(
     proxy: str,
     verify: Any,
     socket_options: tuple[SocketOption, ...] = (),
+    auth: httpx.Auth | None = None,
 ) -> httpx.AsyncClient:
     """httpx.AsyncClient for the openai_proxy code path.
 
@@ -468,14 +470,14 @@ def _build_proxied_async_httpx_client(
     rationale.
     """
     if not socket_options:
-        return httpx.AsyncClient(proxy=proxy, verify=verify)
+        return httpx.AsyncClient(proxy=proxy, verify=verify, auth=auth)
     transport = httpx.AsyncHTTPTransport(
         proxy=httpx.Proxy(proxy),
         verify=verify,
         socket_options=list(socket_options),
         limits=_DEFAULT_CONNECTION_LIMITS,
     )
-    return httpx.AsyncClient(mounts={"all://": transport})
+    return httpx.AsyncClient(mounts={"all://": transport}, auth=auth)
 
 
 @lru_cache

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1292,6 +1292,7 @@ class BaseChatOpenAI(BaseChatModel):
                         proxy=self.openai_proxy,
                         verify=global_ssl_context,
                         socket_options=resolved_socket_options,
+                        auth=gateway_oauth_auth,
                     )
                 if self.http_client:
                     default_http_client = self.http_client
@@ -1320,6 +1321,7 @@ class BaseChatOpenAI(BaseChatModel):
                     proxy=self.openai_proxy,
                     verify=global_ssl_context,
                     socket_options=resolved_socket_options,
+                    auth=gateway_oauth_auth,
                 )
             if self.http_async_client:
                 default_async_http_client = self.http_async_client

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,7 +1212,7 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
-        if self.openai_api_key is None:
+        if self.openai_api_key is None and _base_url_from_gateway:
             gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
             if gateway_api_key is not None:
                 self.openai_api_key = SecretStr(gateway_api_key)

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -112,6 +112,7 @@ from langchain_core.utils.function_calling import (
     convert_to_openai_function,
     convert_to_openai_tool,
 )
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 from langchain_core.utils.pydantic import (
     PydanticBaseModel,
     TypeBaseModel,
@@ -809,6 +810,16 @@ class BaseChatOpenAI(BaseChatModel):
 
     default_query: Mapping[str, object] | None = None
 
+    langsmith_gateway_oauth_token: SecretStr | None = Field(
+        default_factory=secret_from_env("LANGSMITH_GATEWAY_OAUTH_TOKEN", default=None),
+        exclude=True,
+    )
+    """OAuth token used to authenticate this client to LangSmith Gateway.
+
+    When set, the token is sent as an `Authorization` bearer credential and is
+    never passed to OpenAI as an API key.
+    """
+
     # Configure a custom httpx client. See the
     # [httpx documentation](https://www.python-httpx.org/api/#client) for more details.
     http_client: Any | None = Field(default=None, exclude=True)
@@ -1233,6 +1244,13 @@ class BaseChatOpenAI(BaseChatModel):
         }
         if self.max_retries is not None:
             client_params["max_retries"] = self.max_retries
+        gateway_oauth_auth = (
+            LangSmithGatewayOAuth(
+                self.langsmith_gateway_oauth_token.get_secret_value()
+            )
+            if self.langsmith_gateway_oauth_token is not None
+            else None
+        )
 
         if self.openai_proxy and (self.http_client or self.http_async_client):
             openai_proxy = self.openai_proxy
@@ -1280,6 +1298,7 @@ class BaseChatOpenAI(BaseChatModel):
                         self.openai_api_base,
                         self.request_timeout,
                         resolved_socket_options,
+                        gateway_oauth_auth,
                     ),
                     "api_key": sync_api_key_value,
                 }
@@ -1294,10 +1313,11 @@ class BaseChatOpenAI(BaseChatModel):
                 )
             async_specific = {
                 "http_client": self.http_async_client
-                or _get_default_async_httpx_client(
-                    self.openai_api_base,
-                    self.request_timeout,
-                    resolved_socket_options,
+                    or _get_default_async_httpx_client(
+                        self.openai_api_base,
+                        self.request_timeout,
+                        resolved_socket_options,
+                        gateway_oauth_auth,
                 ),
                 "api_key": async_api_key_value,
             }

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1245,12 +1245,13 @@ class BaseChatOpenAI(BaseChatModel):
         if self.max_retries is not None:
             client_params["max_retries"] = self.max_retries
         gateway_oauth_auth = (
-            LangSmithGatewayOAuth(
-                self.langsmith_gateway_oauth_token.get_secret_value()
-            )
-            if self.langsmith_gateway_oauth_token is not None
+            LangSmithGatewayOAuth(self.langsmith_gateway_oauth_token.get_secret_value())
+            if self.langsmith_gateway_oauth_token is not None and _base_url_from_gateway
             else None
         )
+        if gateway_oauth_auth is not None and sync_api_key_value is None:
+            sync_api_key_value = "langsmith-gateway-oauth"
+            async_api_key_value = "langsmith-gateway-oauth"
 
         if self.openai_proxy and (self.http_client or self.http_async_client):
             openai_proxy = self.openai_proxy
@@ -1292,14 +1293,23 @@ class BaseChatOpenAI(BaseChatModel):
                         verify=global_ssl_context,
                         socket_options=resolved_socket_options,
                     )
-                sync_specific = {
-                    "http_client": self.http_client
-                    or _get_default_httpx_client(
+                if self.http_client:
+                    default_http_client = self.http_client
+                elif gateway_oauth_auth is not None:
+                    default_http_client = _get_default_httpx_client(
                         self.openai_api_base,
                         self.request_timeout,
                         resolved_socket_options,
-                        gateway_oauth_auth,
-                    ),
+                        auth=gateway_oauth_auth,
+                    )
+                else:
+                    default_http_client = _get_default_httpx_client(
+                        self.openai_api_base,
+                        self.request_timeout,
+                        resolved_socket_options,
+                    )
+                sync_specific = {
+                    "http_client": default_http_client,
                     "api_key": sync_api_key_value,
                 }
                 self.root_client = openai.OpenAI(**client_params, **sync_specific)  # type: ignore[arg-type]
@@ -1311,14 +1321,23 @@ class BaseChatOpenAI(BaseChatModel):
                     verify=global_ssl_context,
                     socket_options=resolved_socket_options,
                 )
+            if self.http_async_client:
+                default_async_http_client = self.http_async_client
+            elif gateway_oauth_auth is not None:
+                default_async_http_client = _get_default_async_httpx_client(
+                    self.openai_api_base,
+                    self.request_timeout,
+                    resolved_socket_options,
+                    auth=gateway_oauth_auth,
+                )
+            else:
+                default_async_http_client = _get_default_async_httpx_client(
+                    self.openai_api_base,
+                    self.request_timeout,
+                    resolved_socket_options,
+                )
             async_specific = {
-                "http_client": self.http_async_client
-                    or _get_default_async_httpx_client(
-                        self.openai_api_base,
-                        self.request_timeout,
-                        resolved_socket_options,
-                        gateway_oauth_auth,
-                ),
+                "http_client": default_async_http_client,
                 "api_key": async_api_key_value,
             }
             self.root_async_client = openai.AsyncOpenAI(

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1212,6 +1212,11 @@ class BaseChatOpenAI(BaseChatModel):
         sync_api_key_value: str | Callable[[], str] | None = None
         async_api_key_value: str | Callable[[], Awaitable[str]] | None = None
 
+        if self.openai_api_key is None:
+            gateway_api_key = os.getenv("LANGSMITH_GATEWAY_API_KEY")
+            if gateway_api_key is not None:
+                self.openai_api_key = SecretStr(gateway_api_key)
+
         if self.openai_api_key is not None:
             # Because OpenAI and AsyncOpenAI clients support either sync or async
             # callables for the API key, we need to resolve separate values here.

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -178,6 +178,17 @@ def _get_ssrf_safe_client() -> httpx.Client:
 
 _MODEL_PROFILES = cast(ModelProfileRegistry, _PROFILES)
 
+_LANGSMITH_GATEWAY_DEFAULT_URL = "https://gateway.smith.langchain.com/openai/v1"
+
+
+def _resolve_gateway_base_url() -> str | None:
+    raw = os.getenv("LANGSMITH_GATEWAY")
+    if raw is None or raw.lower() in ("false", "0", "no"):
+        return None
+    if raw.lower() in ("true", "1", "yes"):
+        return _LANGSMITH_GATEWAY_DEFAULT_URL
+    return raw
+
 
 def _get_default_model_profile(model_name: str) -> ModelProfile:
     default = _MODEL_PROFILES.get(model_name) or {}
@@ -1167,26 +1178,33 @@ class BaseChatOpenAI(BaseChatModel):
             or os.getenv("OPENAI_ORG_ID")
             or os.getenv("OPENAI_ORGANIZATION")
         )
-        self.openai_api_base = self.openai_api_base or os.getenv("OPENAI_API_BASE")
+        _gateway_base_url = _resolve_gateway_base_url()
+        _base_url_from_gateway = False
+        if self.openai_api_base is None:
+            if _gateway_base_url is not None:
+                self.openai_api_base = _gateway_base_url
+                _base_url_from_gateway = True
+            else:
+                self.openai_api_base = os.getenv("OPENAI_API_BASE")
 
-        # Enable stream_usage by default if using default base URL and client
-        if (
-            all(
-                getattr(self, key, None) is None
-                for key in (
-                    "stream_usage",
-                    "openai_proxy",
-                    "openai_api_base",
-                    "base_url",
-                    "client",
-                    "root_client",
-                    "async_client",
-                    "root_async_client",
-                    "http_client",
-                    "http_async_client",
-                )
+        # Enable stream_usage by default if using default base URL and client,
+        # or when the base URL was set by the LangSmith gateway (which proxies
+        # to OpenAI and supports streaming token usage).
+        if all(
+            getattr(self, key, None) is None
+            for key in (
+                "stream_usage",
+                "openai_proxy",
+                "client",
+                "root_client",
+                "async_client",
+                "root_async_client",
+                "http_client",
+                "http_async_client",
             )
-            and "OPENAI_BASE_URL" not in os.environ
+        ) and (
+            _base_url_from_gateway
+            or (self.openai_api_base is None and "OPENAI_BASE_URL" not in os.environ)
         ):
             self.stream_usage = True
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4505,18 +4505,18 @@ def test_defer_loading_in_responses_api_payload() -> None:
 
 def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
     assert llm.stream_usage is True
 
 
 def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
 
 
 def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
-    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4520,3 +4520,12 @@ def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key=SecretStr("test"))
     assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "gateway-key"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4501,3 +4501,22 @@ def test_defer_loading_in_responses_api_payload() -> None:
     assert weather_tool["defer_loading"] is True
     assert weather_tool["type"] == "function"
     assert {"type": "tool_search"} in result["tools"]
+
+
+def test_langsmith_gateway_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base == "https://gateway.smith.langchain.com/openai/v1"
+    assert llm.stream_usage is True
+
+
+def test_langsmith_gateway_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "false")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None
+
+
+def test_langsmith_gateway_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL, api_key="test")
+    assert llm.openai_api_base is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4540,3 +4540,31 @@ def test_langsmith_gateway_api_key_not_used_without_gateway(
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
     assert isinstance(llm.openai_api_key, SecretStr)
     assert llm.openai_api_key.get_secret_value() == "provider-key"
+
+
+def test_langsmith_gateway_oauth_uses_placeholder_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+
+    assert llm.root_client.api_key == "langsmith-gateway-oauth"
+
+
+def test_langsmith_gateway_oauth_is_not_used_for_custom_base_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+
+    llm = ChatOpenAI(
+        model=OPENAI_TEST_MODEL,
+        api_key="provider-key",
+        base_url="https://api.openai.com/v1",
+    )
+
+    assert llm.root_client._client.auth is None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4529,3 +4529,14 @@ def test_langsmith_gateway_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
     assert isinstance(llm.openai_api_key, SecretStr)
     assert llm.openai_api_key.get_secret_value() == "gateway-key"
+
+
+def test_langsmith_gateway_api_key_not_used_without_gateway(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("LANGSMITH_GATEWAY", raising=False)
+    monkeypatch.setenv("LANGSMITH_GATEWAY_API_KEY", "gateway-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "provider-key")
+    llm = ChatOpenAI(model=OPENAI_TEST_MODEL)
+    assert isinstance(llm.openai_api_key, SecretStr)
+    assert llm.openai_api_key.get_secret_value() == "provider-key"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -4563,7 +4563,7 @@ def test_langsmith_gateway_oauth_is_not_used_for_custom_base_url(
 
     llm = ChatOpenAI(
         model=OPENAI_TEST_MODEL,
-        api_key="provider-key",
+        api_key=SecretStr("provider-key"),
         base_url="https://api.openai.com/v1",
     )
 

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
@@ -213,9 +213,19 @@ def test_openai_proxy_branch_applies_socket_options(
     """`openai_proxy` path must go through the socket-options-aware proxied helper."""
     recorded: list[dict[str, Any]] = []
 
-    def spy(proxy: str, verify: Any, socket_options: tuple = ()) -> httpx.AsyncClient:
+    def spy(
+        proxy: str,
+        verify: Any,
+        socket_options: tuple = (),
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
         recorded.append(
-            {"proxy": proxy, "verify": verify, "socket_options": socket_options}
+            {
+                "proxy": proxy,
+                "verify": verify,
+                "socket_options": socket_options,
+                "auth": auth,
+            }
         )
         return httpx.AsyncClient()
 
@@ -226,9 +236,19 @@ def test_openai_proxy_branch_applies_socket_options(
     # Sync branch should also be covered — spy on that too.
     sync_recorded: list[dict[str, Any]] = []
 
-    def sync_spy(proxy: str, verify: Any, socket_options: tuple = ()) -> httpx.Client:
+    def sync_spy(
+        proxy: str,
+        verify: Any,
+        socket_options: tuple = (),
+        auth: httpx.Auth | None = None,
+    ) -> httpx.Client:
         sync_recorded.append(
-            {"proxy": proxy, "verify": verify, "socket_options": socket_options}
+            {
+                "proxy": proxy,
+                "verify": verify,
+                "socket_options": socket_options,
+                "auth": auth,
+            }
         )
         return httpx.Client()
 
@@ -250,6 +270,25 @@ def test_openai_proxy_branch_applies_socket_options(
     assert sync_recorded, "expected sync proxied helper to be called"
     assert sync_recorded[-1]["proxy"] == "http://proxy.example.com:3128"
     assert sync_recorded[-1]["socket_options"] == ((SOL_SOCKET, SO_KEEPALIVE, 1),)
+    assert sync_recorded[-1]["auth"] is None
+    assert recorded[-1]["auth"] is None
+
+
+def test_gateway_oauth_is_applied_to_explicit_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LANGSMITH_GATEWAY", "true")
+    monkeypatch.setenv("LANGSMITH_GATEWAY_OAUTH_TOKEN", "oauth-token")
+    monkeypatch.delenv("LANGSMITH_GATEWAY_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    llm = ChatOpenAI(
+        model=OPENAI_TEST_MODEL,
+        openai_proxy="http://proxy.example.com:3128",
+    )
+
+    assert isinstance(llm.root_client._client.auth, LangSmithGatewayOAuth)
+    assert isinstance(llm.root_async_client._client.auth, LangSmithGatewayOAuth)
 
 
 def test_user_supplied_http_async_client_untouched(

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_client_utils.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import httpx
 import pytest
+from langchain_core.utils.langsmith_gateway import LangSmithGatewayOAuth
 
 from langchain_openai import ChatOpenAI
 from langchain_openai.chat_models import _client_utils
@@ -457,6 +458,36 @@ def test_build_proxied_async_httpx_client_opt_out_returns_plain_client() -> None
         socket_options=(),
     )
     assert isinstance(client, httpx.AsyncClient)
+
+
+@pytest.mark.parametrize("is_async", [False, True])
+def test_gateway_oauth_preserves_proxy_discovery_without_socket_options(
+    monkeypatch: pytest.MonkeyPatch,
+    is_async: bool,
+) -> None:
+    """OAuth clients omit a transport when proxy discovery must remain enabled."""
+    captured: dict[str, Any] = {}
+
+    def wrapper(**kwargs: Any) -> object:
+        captured.update(kwargs)
+        return object()
+
+    wrapper_name = "_AsyncHttpxClientWrapper" if is_async else "_SyncHttpxClientWrapper"
+    monkeypatch.setattr(_client_utils, wrapper_name, wrapper)
+    get_client = (
+        _client_utils._get_default_async_httpx_client
+        if is_async
+        else _client_utils._get_default_httpx_client
+    )
+
+    get_client(
+        base_url="https://gateway.smith.langchain.com/openai/v1",
+        timeout=None,
+        auth=LangSmithGatewayOAuth("oauth-token"),
+    )
+
+    assert captured["auth"].__class__ is LangSmithGatewayOAuth
+    assert "transport" not in captured
 
 
 def test_build_proxied_async_httpx_client_wraps_transport() -> None:


### PR DESCRIPTION
Gateway-backed chat clients can now use a LangSmith OAuth access token as an `Authorization: Bearer` credential without treating it as a provider API key. The shared transport adapter removes provider auth headers before sending the request, and the OpenAI, Anthropic, and Fireworks clients use it when an OAuth token is configured.

## Release note

Add OAuth bearer authentication for LangSmith Gateway chat requests in the OpenAI, Anthropic, and Fireworks integrations.

This contribution was prepared with AI assistance.