### PR TITLE
feat(ollama): native content-block streaming events

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -564,6 +564,75 @@ def _finalize_and_build_finish(
 
 
 # ---------------------------------------------------------------------------
+# Shared block-lifecycle tracker
+# ---------------------------------------------------------------------------
+
+
+class BlockStreamTracker:
+    """Allocate wire indices and emit content-block lifecycle events.
+
+    Single source of truth for the start/delta/accumulate/finalize
+    mechanics shared by the compat bridge and provider-native converters.
+    Source-side keys (a block's `index` field, int or str, or a
+    positional fallback) are mapped to sequential `uint` wire indices.
+    """
+
+    def __init__(self) -> None:
+        self._blocks: dict[Any, tuple[int, CompatBlock]] = {}
+        self._next_wire_idx = 0
+
+    def feed(self, key: Any, block: CompatBlock) -> Iterator[MessagesData]:
+        """Yield lifecycle events for a per-chunk block.
+
+        Yields `content-block-start` the first time `key` is seen, then
+        `content-block-delta` when the block carries fresh content,
+        accumulating per-index state for later finalization.
+        """
+        if key not in self._blocks:
+            wire_idx = self._next_wire_idx
+            self._next_wire_idx += 1
+            self._blocks[key] = (wire_idx, dict(block))
+            yield ContentBlockStartData(
+                event="content-block-start",
+                index=wire_idx,
+                content=_start_skeleton(block),
+            )
+        else:
+            wire_idx, existing = self._blocks[key]
+            self._blocks[key] = (wire_idx, _accumulate(existing, block))
+        if _should_emit_delta(block):
+            wire_idx, current = self._blocks[key]
+            is_block_delta = block.get("type") in (
+                "tool_call_chunk",
+                "server_tool_call_chunk",
+            )
+            delta_source = current if is_block_delta else block
+            yield ContentBlockDeltaData(
+                event="content-block-delta",
+                index=wire_idx,
+                delta=_to_content_delta(delta_source or block),
+            )
+
+    def finish_block(self, key: Any) -> Iterator[MessagesData]:
+        """Finalize and close one block at its true stop boundary.
+
+        Native converters call this on the provider's block-stop signal.
+        A no-op for unknown / already-closed keys.
+        """
+        entry = self._blocks.pop(key, None)
+        if entry is None:
+            return
+        wire_idx, block = entry
+        yield _finalize_and_build_finish(wire_idx, block)
+
+    def finish_all(self) -> Iterator[MessagesData]:
+        """Finalize every still-open block, in wire-index order."""
+        for wire_idx, block in self._blocks.values():
+            yield _finalize_and_build_finish(wire_idx, block)
+        self._blocks.clear()
+
+
+# ---------------------------------------------------------------------------
 # Main generators
 # ---------------------------------------------------------------------------
 
@@ -590,8 +659,7 @@ def chunks_to_events(
         `MessagesData` lifecycle events.
     """
     started = False
-    blocks: dict[Any, tuple[int, CompatBlock]] = {}
-    next_wire_idx = 0
+    tracker = BlockStreamTracker()
     usage: dict[str, Any] | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
@@ -633,30 +701,7 @@ def chunks_to_events(
             yield _build_message_start(msg, message_id)
 
         for key, block in _iter_protocol_blocks(msg):
-            if key not in blocks:
-                wire_idx = next_wire_idx
-                next_wire_idx += 1
-                blocks[key] = (wire_idx, dict(block))
-                yield ContentBlockStartData(
-                    event="content-block-start",
-                    index=wire_idx,
-                    content=_start_skeleton(block),
-                )
-            else:
-                wire_idx, existing = blocks[key]
-                blocks[key] = (wire_idx, _accumulate(existing, block))
-            if _should_emit_delta(block):
-                wire_idx, current = blocks[key]
-                is_block_delta = block.get("type") in (
-                    "tool_call_chunk",
-                    "server_tool_call_chunk",
-                )
-                delta_source = current if is_block_delta else block
-                yield ContentBlockDeltaData(
-                    event="content-block-delta",
-                    index=wire_idx,
-                    delta=_to_content_delta(delta_source or block),
-                )
+            yield from tracker.feed(key, block)
 
         if msg.usage_metadata:
             usage = _accumulate_usage(usage, msg.usage_metadata)
@@ -664,8 +709,7 @@ def chunks_to_events(
     if not started:
         return
 
-    for wire_idx, block in blocks.values():
-        yield _finalize_and_build_finish(wire_idx, block)
+    yield from tracker.finish_all()
 
     yield _build_message_finish(
         usage=usage,
@@ -681,8 +725,7 @@ async def achunks_to_events(
 ) -> AsyncIterator[MessagesData]:
     """Async variant of `chunks_to_events`."""
     started = False
-    blocks: dict[Any, tuple[int, CompatBlock]] = {}
-    next_wire_idx = 0
+    tracker = BlockStreamTracker()
     usage: dict[str, Any] | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
@@ -713,30 +756,8 @@ async def achunks_to_events(
             yield _build_message_start(msg, message_id)
 
         for key, block in _iter_protocol_blocks(msg):
-            if key not in blocks:
-                wire_idx = next_wire_idx
-                next_wire_idx += 1
-                blocks[key] = (wire_idx, dict(block))
-                yield ContentBlockStartData(
-                    event="content-block-start",
-                    index=wire_idx,
-                    content=_start_skeleton(block),
-                )
-            else:
-                wire_idx, existing = blocks[key]
-                blocks[key] = (wire_idx, _accumulate(existing, block))
-            if _should_emit_delta(block):
-                wire_idx, current = blocks[key]
-                is_block_delta = block.get("type") in (
-                    "tool_call_chunk",
-                    "server_tool_call_chunk",
-                )
-                delta_source = current if is_block_delta else block
-                yield ContentBlockDeltaData(
-                    event="content-block-delta",
-                    index=wire_idx,
-                    delta=_to_content_delta(delta_source or block),
-                )
+            for event in tracker.feed(key, block):
+                yield event
 
         if msg.usage_metadata:
             usage = _accumulate_usage(usage, msg.usage_metadata)
@@ -744,8 +765,8 @@ async def achunks_to_events(
     if not started:
         return
 
-    for wire_idx, block in blocks.values():
-        yield _finalize_and_build_finish(wire_idx, block)
+    for event in tracker.finish_all():
+        yield event
 
     yield _build_message_finish(
         usage=usage,
@@ -816,6 +837,7 @@ async def amessage_to_events(
 
 
 __all__ = [
+    "BlockStreamTracker",
     "CompatBlock",
     "achunks_to_events",
     "amessage_to_events",

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -667,8 +667,16 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             getattr(self, "_stream_chat_model_events", None),
         )
         if native is not None:
+            # Thread the stream's message id (the LangChain run id) into the
+            # native producer so its `message-start` carries the same id the
+            # bridge path emits — keeping the two paths consistent for
+            # consumers that correlate v3 events by `message-start.id`.
             event_iter: Iterator[MessagesData] = native(
-                messages, stop=stop, run_manager=run_manager, **kwargs
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                message_id=stream.message_id,
+                **kwargs,
             )
         else:
             event_iter = chunks_to_events(
@@ -698,8 +706,14 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             getattr(self, "_astream_chat_model_events", None),
         )
         if native is not None:
+            # See `_iter_v2_events`: thread the stream's message id into the
+            # native producer for `message-start` consistency with the bridge.
             event_iter: AsyncIterator[MessagesData] = native(
-                messages, stop=stop, run_manager=run_manager, **kwargs
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                message_id=stream.message_id,
+                **kwargs,
             )
         else:
             event_iter = achunks_to_events(

--- a/libs/core/langchain_core/language_models/stream_events.py
+++ b/libs/core/langchain_core/language_models/stream_events.py
@@ -1,0 +1,28 @@
+"""Shared primitives for provider-native streaming-event converters.
+
+Provider packages implementing `_stream_chat_model_events` import these
+to drive raw API events into the same content-block lifecycle the compat
+bridge produces, so native and bridged paths emit identical event shapes.
+"""
+
+from langchain_core.language_models._compat_bridge import (
+    BlockStreamTracker,
+    finalize_tool_call_chunk,
+)
+from langchain_core.language_models._compat_bridge import (
+    _accumulate_usage as accumulate_usage,
+)
+from langchain_core.language_models._compat_bridge import (
+    _build_message_finish as build_message_finish,
+)
+from langchain_core.language_models._compat_bridge import (
+    _iter_protocol_blocks as iter_protocol_blocks,
+)
+
+__all__ = [
+    "BlockStreamTracker",
+    "accumulate_usage",
+    "build_message_finish",
+    "finalize_tool_call_chunk",
+    "iter_protocol_blocks",
+]

--- a/libs/core/tests/unit_tests/language_models/test_block_stream_tracker.py
+++ b/libs/core/tests/unit_tests/language_models/test_block_stream_tracker.py
@@ -1,0 +1,65 @@
+"""Unit tests for the shared BlockStreamTracker."""
+
+from typing import Any
+
+from langchain_core.language_models.stream_events import BlockStreamTracker
+
+
+def test_feed_text_emits_start_then_delta() -> None:
+    tracker = BlockStreamTracker()
+    events: list[Any] = list(
+        tracker.feed(0, {"type": "text", "text": "Hi", "index": 0})
+    )
+    assert events[0]["event"] == "content-block-start"
+    assert events[0]["index"] == 0
+    assert events[0]["content"] == {"type": "text", "text": ""}
+    assert events[1]["event"] == "content-block-delta"
+    assert events[1]["index"] == 0
+    assert events[1]["delta"] == {"type": "text-delta", "text": "Hi"}
+
+
+def test_feed_allocates_sequential_wire_indices() -> None:
+    tracker = BlockStreamTracker()
+    list(tracker.feed("a", {"type": "text", "text": "x", "index": "a"}))
+    second: list[Any] = list(
+        tracker.feed("b", {"type": "text", "text": "y", "index": "b"})
+    )
+    assert second[0]["index"] == 1  # second distinct key -> wire index 1
+
+
+def test_finish_block_finalizes_tool_call_at_boundary() -> None:
+    tracker = BlockStreamTracker()
+    list(
+        tracker.feed(
+            0,
+            {
+                "type": "tool_call_chunk",
+                "id": "t1",
+                "name": "f",
+                "args": '{"a":',
+                "index": 0,
+            },
+        )
+    )
+    list(tracker.feed(0, {"type": "tool_call_chunk", "args": "1}", "index": 0}))
+    finished: list[Any] = list(tracker.finish_block(0))
+    assert len(finished) == 1
+    assert finished[0]["event"] == "content-block-finish"
+    assert finished[0]["content"]["type"] == "tool_call"
+    assert finished[0]["content"]["args"] == {"a": 1}
+    # finished block is closed: finish_all must not re-emit it
+    assert list(tracker.finish_all()) == []
+
+
+def test_finish_block_unknown_key_is_noop() -> None:
+    assert list(BlockStreamTracker().finish_block("nope")) == []
+
+
+def test_finish_all_finalizes_open_blocks_in_wire_order() -> None:
+    tracker = BlockStreamTracker()
+    list(tracker.feed(0, {"type": "text", "text": "hello", "index": 0}))
+    list(tracker.feed(1, {"type": "reasoning", "reasoning": "why", "index": 1}))
+    finished: list[Any] = list(tracker.finish_all())
+    assert [f["index"] for f in finished] == [0, 1]
+    assert finished[0]["content"]["text"] == "hello"
+    assert finished[1]["content"]["reasoning"] == "why"

--- a/libs/partners/anthropic/langchain_anthropic/_stream_events.py
+++ b/libs/partners/anthropic/langchain_anthropic/_stream_events.py
@@ -1,0 +1,147 @@
+"""Native content-block streaming-event converter for Anthropic.
+
+Maps the raw Anthropic SDK stream (``message_start`` /
+``content_block_start`` / ``content_block_delta`` / ``content_block_stop`` /
+``message_delta`` / ``message_stop``) to the protocol ``MessagesData``
+event lifecycle, reusing the shared ``BlockStreamTracker`` for block
+mechanics and the existing per-event chunk builder for content extraction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.language_models.stream_events import (
+    BlockStreamTracker,
+    accumulate_usage,
+    build_message_finish,
+    iter_protocol_blocks,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from langchain_core.messages import AIMessageChunk
+    from langchain_protocol.protocol import (
+        MessageMetadata,
+        MessagesData,
+        MessageStartData,
+    )
+
+# The bound method ``ChatAnthropic._make_message_chunk_from_anthropic_event``.
+MakeChunk = Callable[..., "tuple[AIMessageChunk | None, Any]"]
+
+
+def _message_start(event: Any, message_id: str | None) -> MessageStartData:
+    msg_obj = getattr(event, "message", None)
+    # Do not use the provider message id (`msg_...`) here: on the v3 path core
+    # seeds the stream with the LangChain run id, and an empty id lets that
+    # stand (matching the compat bridge). Only an explicit `message_id` wins.
+    resolved_id = message_id or ""
+    metadata: MessageMetadata = {"provider": "anthropic"}
+    model = getattr(msg_obj, "model", None)
+    if model:
+        metadata["model"] = model
+    return {
+        "event": "message-start",
+        "role": "ai",
+        "id": resolved_id,
+        "metadata": metadata,
+    }
+
+
+def convert_anthropic_stream(
+    raw: Iterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    stream_usage: bool = True,
+    message_id: str | None = None,
+) -> Iterator[MessagesData]:
+    """Convert a raw Anthropic event stream to protocol events.
+
+    Args:
+        raw: Raw Anthropic SDK stream events.
+        make_chunk: ``ChatAnthropic._make_message_chunk_from_anthropic_event``,
+            injected so the converter stays pure and unit-testable.
+        stream_usage: Forwarded to ``make_chunk``.
+        message_id: Overrides the provider message id on ``message-start``.
+
+    Yields:
+        Protocol ``MessagesData`` lifecycle events.
+    """
+    tracker = BlockStreamTracker()
+    started = False
+    block_start_event: Any = None
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "anthropic"}
+
+    for event in raw:
+        etype = getattr(event, "type", None)
+        chunk_msg, block_start_event = make_chunk(
+            event,
+            stream_usage=stream_usage,
+            coerce_content_to_string=False,
+            block_start_event=block_start_event,
+        )
+        if not started:
+            started = True
+            yield _message_start(event, message_id)
+        if chunk_msg is not None:
+            for key, block in iter_protocol_blocks(chunk_msg):
+                yield from tracker.feed(key, block)
+            if chunk_msg.usage_metadata:
+                usage = accumulate_usage(usage, chunk_msg.usage_metadata)
+            if chunk_msg.response_metadata:
+                response_metadata.update(chunk_msg.response_metadata)
+        if etype == "content_block_stop":
+            yield from tracker.finish_block(getattr(event, "index", None))
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_anthropic_stream(
+    raw: AsyncIterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    stream_usage: bool = True,
+    message_id: str | None = None,
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_anthropic_stream`. `make_chunk` is sync."""
+    tracker = BlockStreamTracker()
+    started = False
+    block_start_event: Any = None
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "anthropic"}
+
+    async for event in raw:
+        etype = getattr(event, "type", None)
+        chunk_msg, block_start_event = make_chunk(
+            event,
+            stream_usage=stream_usage,
+            coerce_content_to_string=False,
+            block_start_event=block_start_event,
+        )
+        if not started:
+            started = True
+            yield _message_start(event, message_id)
+        if chunk_msg is not None:
+            for key, block in iter_protocol_blocks(chunk_msg):
+                for ev in tracker.feed(key, block):
+                    yield ev
+            if chunk_msg.usage_metadata:
+                usage = accumulate_usage(usage, chunk_msg.usage_metadata)
+            if chunk_msg.response_metadata:
+                response_metadata.update(chunk_msg.response_metadata)
+        if etype == "content_block_stop":
+            for ev in tracker.finish_block(getattr(event, "index", None)):
+                yield ev
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from functools import cached_property
 from operator import itemgetter
-from typing import Any, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 import anthropic
 from langchain_core.callbacks import (
@@ -64,8 +64,15 @@ from langchain_anthropic._client_utils import (
     _get_default_httpx_client,
 )
 from langchain_anthropic._compat import _convert_from_v1_to_anthropic
+from langchain_anthropic._stream_events import (
+    aconvert_anthropic_stream,
+    convert_anthropic_stream,
+)
 from langchain_anthropic.data._profiles import _PROFILES
 from langchain_anthropic.output_parsers import extract_tool_calls
+
+if TYPE_CHECKING:
+    from langchain_protocol.protocol import ContentBlockDelta, MessagesData
 
 _message_type_lookups = {
     "human": "user",
@@ -874,6 +881,13 @@ def _handle_anthropic_bad_request(e: anthropic.BadRequestError) -> None:
     raise
 
 
+def _delta_text_for_callback(delta: ContentBlockDelta) -> str:
+    """Text increment to report via `on_llm_new_token` (empty for non-text)."""
+    if delta.get("type") == "text-delta":
+        return cast("str", delta.get("text", ""))
+    return ""
+
+
 class ChatAnthropic(BaseChatModel):
     """Anthropic (Claude) chat models.
 
@@ -1506,6 +1520,74 @@ class ChatAnthropic(BaseChatModel):
                     if run_manager and isinstance(msg.content, str):
                         await run_manager.on_llm_new_token(msg.content, chunk=chunk)
                     yield chunk
+        except anthropic.BadRequestError as e:
+            _handle_anthropic_bad_request(e)
+
+    def _stream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        *,
+        stream_usage: bool | None = None,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[MessagesData]:
+        """Emit Anthropic-native content-block protocol events.
+
+        Detected by `langchain-core`'s `_iter_v2_events`; powers
+        `stream_events(version="v3")`. Falls through to the compat bridge
+        only if this method is absent. `message_id` is threaded from the
+        stream so `message-start` matches the bridge's LangChain run id.
+        """
+        if stream_usage is None:
+            stream_usage = self.stream_usage
+        kwargs["stream"] = True
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            raw = self._create(payload)
+            for event in convert_anthropic_stream(
+                raw,
+                self._make_message_chunk_from_anthropic_event,
+                stream_usage=stream_usage,
+                message_id=message_id,
+            ):
+                if run_manager is not None and event["event"] == "content-block-delta":
+                    token = _delta_text_for_callback(event["delta"])
+                    if token:
+                        run_manager.on_llm_new_token(token)
+                yield event
+        except anthropic.BadRequestError as e:
+            _handle_anthropic_bad_request(e)
+
+    async def _astream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        *,
+        stream_usage: bool | None = None,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[MessagesData]:
+        """Async twin of `_stream_chat_model_events`."""
+        if stream_usage is None:
+            stream_usage = self.stream_usage
+        kwargs["stream"] = True
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            raw = await self._acreate(payload)
+            async for event in aconvert_anthropic_stream(
+                raw,
+                self._make_message_chunk_from_anthropic_event,
+                stream_usage=stream_usage,
+                message_id=message_id,
+            ):
+                if run_manager is not None and event["event"] == "content-block-delta":
+                    token = _delta_text_for_callback(event["delta"])
+                    if token:
+                        await run_manager.on_llm_new_token(token)
+                yield event
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3222,19 +3222,12 @@ def test_no_task_budget_no_beta() -> None:
         assert "task-budgets-2026-03-13" not in betas
 
 
-def test_anthropic_stream_events_v3_lifecycle() -> None:
-    """Validate lifecycle events across a thinking + text + tool_use stream.
+def _lifecycle_events() -> list[Any]:
+    """Build a raw thinking + text + tool_use Anthropic stream fixture.
 
-    Anthropic emits raw `content_block_start` / `content_block_delta` /
-    `content_block_stop` events with integer `index` fields, interleaved
-    with `message_start` and `message_delta`. This test threads a
-    realistic event sequence through `_stream` via a mocked raw client
-    and asserts that `stream_events(version="v3")` produces a spec-conformant
-    event stream: paired start/finish per block, no interleaving, sequential
-    `uint` wire indices.
+    Shared by the sync and async v3 lifecycle parity tests so both exercise
+    the identical event sequence through the native hooks.
     """
-    from unittest.mock import patch
-
     from anthropic.types import (
         InputJSONDelta,
         RawContentBlockDeltaEvent,
@@ -3252,7 +3245,6 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     from anthropic.types.raw_message_delta_event import (
         MessageDeltaUsage as RawMessageDeltaUsage,
     )
-    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 
     msg = Message(
         id="msg_1",
@@ -3265,7 +3257,7 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         type="message",
     )
 
-    events = [
+    return [
         RawMessageStartEvent(message=msg, type="message_start"),
         # thinking block (index=0)
         RawContentBlockStartEvent(
@@ -3337,6 +3329,24 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         RawMessageStopEvent(type="message_stop"),
     ]
 
+
+def test_anthropic_stream_events_v3_lifecycle() -> None:
+    """Validate lifecycle events across a thinking + text + tool_use stream.
+
+    Anthropic emits raw `content_block_start` / `content_block_delta` /
+    `content_block_stop` events with integer `index` fields, interleaved
+    with `message_start` and `message_delta`. This test threads a
+    realistic event sequence through `_stream` via a mocked raw client
+    and asserts that `stream_events(version="v3")` produces a spec-conformant
+    event stream: paired start/finish per block, no interleaving, sequential
+    `uint` wire indices.
+    """
+    from unittest.mock import patch
+
+    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+    events = _lifecycle_events()
+
     # Enable thinking so `coerce_content_to_string=False` in `_stream`,
     # which gives every content block an integer `index` field — the
     # structured path the protocol bridge actually exercises.  Default
@@ -3354,6 +3364,14 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         stream_events = list(llm.stream_events("Test query", version="v3"))
 
     assert_valid_event_stream(stream_events)
+
+    # `message-start` must carry the stream's LangChain run id (threaded from
+    # core), matching the bridge path — not the provider message id ("msg_1")
+    # and not an empty string.
+    message_start = cast("dict[str, Any]", stream_events[0])
+    assert message_start["event"] == "message-start"
+    assert message_start["id"]
+    assert message_start["id"] != "msg_1"
 
     finishes = [e for e in stream_events if e["event"] == "content-block-finish"]
     types = [f["content"]["type"] for f in finishes]
@@ -3378,3 +3396,36 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+async def test_anthropic_astream_events_v3_lifecycle() -> None:
+    """Async twin of `test_anthropic_stream_events_v3_lifecycle`.
+
+    Exercises `_astream_chat_model_events` end-to-end via the
+    `AsyncChatModelStream` producer task.
+    """
+    from unittest.mock import patch
+
+    events = _lifecycle_events()
+    llm = ChatAnthropic(
+        model=MODEL_NAME, thinking={"type": "enabled", "budget_tokens": 1024}
+    )
+
+    async def mock_acreate(_payload: Any) -> Any:
+        async def _gen() -> Any:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    with patch.object(llm, "_acreate", mock_acreate):
+        stream = await llm.astream_events("Test query", version="v3")
+        collected = [e async for e in stream]
+
+    finishes = [e for e in collected if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert collected[-1]["metadata"]["stop_reason"] == "tool_use"

--- a/libs/partners/anthropic/tests/unit_tests/test_stream_events.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_stream_events.py
@@ -1,0 +1,182 @@
+"""Unit tests for the Anthropic native stream-events converter."""
+
+from typing import Any, cast
+
+from anthropic.types import (
+    InputJSONDelta,
+    Message,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolUseBlock,
+    Usage,
+)
+from anthropic.types.raw_message_delta_event import Delta as RawMessageDelta
+from anthropic.types.raw_message_delta_event import (
+    MessageDeltaUsage as RawMessageDeltaUsage,
+)
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic._stream_events import convert_anthropic_stream
+
+MODEL_NAME = "claude-haiku-4-5-20251001"
+
+
+def _events() -> list[Any]:
+    msg = Message(
+        id="msg_1",
+        content=[],
+        model=MODEL_NAME,
+        role="assistant",
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(input_tokens=10, output_tokens=0),
+        type="message",
+    )
+    return [
+        RawMessageStartEvent(message=msg, type="message_start"),
+        RawContentBlockStartEvent(
+            content_block=ThinkingBlock(signature="", thinking="", type="thinking"),
+            index=0,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=ThinkingDelta(thinking="Let me ", type="thinking_delta"),
+            index=0,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=ThinkingDelta(thinking="think.", type="thinking_delta"),
+            index=0,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=0, type="content_block_stop"),
+        RawContentBlockStartEvent(
+            content_block=TextBlock(text="", type="text"),
+            index=1,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=TextDelta(text="The answer ", type="text_delta"),
+            index=1,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=TextDelta(text="is 42.", type="text_delta"),
+            index=1,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=1, type="content_block_stop"),
+        RawContentBlockStartEvent(
+            content_block=ToolUseBlock(
+                id="toolu_1", input={}, name="search", type="tool_use"
+            ),
+            index=2,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=InputJSONDelta(partial_json='{"q":', type="input_json_delta"),
+            index=2,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=InputJSONDelta(partial_json=' "weather"}', type="input_json_delta"),
+            index=2,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=2, type="content_block_stop"),
+        RawMessageDeltaEvent(
+            delta=RawMessageDelta(stop_reason="tool_use", stop_sequence=None),
+            type="message_delta",
+            usage=RawMessageDeltaUsage(
+                output_tokens=50,
+                input_tokens=10,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        ),
+        RawMessageStopEvent(type="message_stop"),
+    ]
+
+
+def test_convert_anthropic_stream_lifecycle() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME)
+    events: list[Any] = list(
+        convert_anthropic_stream(
+            iter(_events()), llm._make_message_chunk_from_anthropic_event
+        )
+    )
+
+    assert_valid_event_stream(events)
+
+    assert events[0]["event"] == "message-start"
+    # The provider message id (`msg_1`) is deliberately NOT used: on the v3 path
+    # core seeds the stream with the LangChain run id, and an empty id here lets
+    # that stand (matching the compat bridge). Only an explicit `message_id`
+    # overrides it.
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "anthropic"
+    assert events[0]["metadata"]["model"] == MODEL_NAME
+
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert [f["index"] for f in finishes] == [0, 1, 2]
+    reasoning = cast("dict[str, Any]", finishes[0]["content"])
+    text = cast("dict[str, Any]", finishes[1]["content"])
+    assert reasoning["reasoning"] == "Let me think."
+    assert text["text"] == "The answer is 42."
+    tool = cast("dict[str, Any]", finishes[2]["content"])
+    assert tool["args"] == {"q": "weather"}
+    assert tool["name"] == "search"
+
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["metadata"]["stop_reason"] == "tool_use"
+    # content-block-finish for index 0 arrives before index 1 starts
+    # (true stop boundaries, not all-at-end).
+    first_finish = next(
+        i for i, e in enumerate(events) if e["event"] == "content-block-finish"
+    )
+    first_idx1_start = next(
+        i
+        for i, e in enumerate(events)
+        if e["event"] == "content-block-start" and e["index"] == 1
+    )
+    assert first_finish < first_idx1_start
+
+
+async def test_aconvert_anthropic_stream_lifecycle() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    async def _araw() -> Any:
+        for event in _events():
+            yield event
+
+    from langchain_anthropic._stream_events import aconvert_anthropic_stream
+
+    events: list[Any] = [
+        e
+        async for e in aconvert_anthropic_stream(
+            _araw(), llm._make_message_chunk_from_anthropic_event
+        )
+    ]
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert events[-1]["metadata"]["stop_reason"] == "tool_use"

--- a/libs/partners/ollama/langchain_ollama/_stream_events.py
+++ b/libs/partners/ollama/langchain_ollama/_stream_events.py
@@ -1,0 +1,230 @@
+"""Native content-block streaming-event converter for Ollama.
+
+Maps the raw Ollama chat stream (dicts with `message.content`,
+`message.thinking`, `message.tool_calls`, and final `done`/usage fields) to the
+protocol `MessagesData` lifecycle, feeding the shared `BlockStreamTracker`.
+Unlike the compat bridge (which buries reasoning in `additional_kwargs`), this
+surfaces thinking as real `reasoning` content blocks.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
+
+from langchain_core.language_models.stream_events import (
+    BlockStreamTracker,
+    accumulate_usage,
+    build_message_finish,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from langchain_core.messages import ToolCall
+    from langchain_protocol.protocol import (
+        MessageMetadata,
+        MessagesData,
+        MessageStartData,
+    )
+
+# Bound `_get_tool_calls_from_response`.
+GetToolCalls = Callable[[Any], "list[ToolCall]"]
+
+# Stable per-block keys for the tracker (Ollama gives no indices).
+_TEXT_KEY = "text"
+_REASONING_KEY = "reasoning"
+
+
+def _message_start(message_id: str | None, model: str | None) -> MessageStartData:
+    metadata: MessageMetadata = {"provider": "ollama"}
+    if model:
+        metadata["model"] = model
+    # `cast` rather than a bare TypedDict literal: the strict `ty` checker
+    # rejects the literal against the external `MessageStartData` TypedDict.
+    return cast(
+        "MessageStartData",
+        {
+            "event": "message-start",
+            "role": "ai",
+            "id": message_id or "",
+            "metadata": metadata,
+        },
+    )
+
+
+def convert_ollama_stream(
+    raw: Iterator[Any],
+    get_tool_calls: GetToolCalls,
+    *,
+    reasoning: bool | None = None,
+    message_id: str | None = None,
+) -> Iterator[MessagesData]:
+    """Convert a raw Ollama chat stream to protocol events.
+
+    Args:
+        raw: Raw Ollama stream items (dicts; non-dicts skipped).
+        get_tool_calls: `ChatOllama`'s `_get_tool_calls_from_response`, injected
+            so the converter stays pure.
+        reasoning: When truthy, surface `message.thinking` as reasoning blocks.
+        message_id: Left empty by default so the v3 stream's seeded run id stands.
+
+    Yields:
+        Protocol `MessagesData` lifecycle events.
+    """
+    # Local import to avoid a circular import: `chat_models` imports this module.
+    from langchain_ollama.chat_models import (  # noqa: PLC0415
+        _get_usage_metadata_from_generation_info,
+    )
+
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "ollama"}
+    tool_idx = 0
+
+    for resp in raw:
+        if not isinstance(resp, dict):
+            continue
+
+        message = resp.get("message") or {}
+
+        # Skip "load" responses with empty content, matching the compat bridge
+        # (`_iterate_over_stream`): the model was loaded but generated nothing,
+        # so emitting an empty message-start/finish would diverge from the bridge.
+        content = message.get("content") or ""
+        if (
+            resp.get("done") is True
+            and resp.get("done_reason") == "load"
+            and not content.strip()
+        ):
+            continue
+
+        if not started:
+            started = True
+            yield _message_start(message_id, resp.get("model"))
+
+        thinking = message.get("thinking")
+        if reasoning and thinking:
+            yield from tracker.feed(
+                _REASONING_KEY, {"type": "reasoning", "reasoning": thinking}
+            )
+
+        if content:
+            yield from tracker.feed(_TEXT_KEY, {"type": "text", "text": content})
+
+        if message.get("tool_calls"):
+            for tc in get_tool_calls(resp):
+                yield from tracker.feed(
+                    f"tool:{tool_idx}",
+                    {
+                        "type": "tool_call_chunk",
+                        "id": tc.get("id"),
+                        "name": tc.get("name"),
+                        "args": json.dumps(tc.get("args") or {}),
+                    },
+                )
+                tool_idx += 1
+
+        if resp.get("done") is True:
+            usage = accumulate_usage(
+                usage, _get_usage_metadata_from_generation_info(resp)
+            )
+            done_meta = {
+                k: v for k, v in resp.items() if k != "message" and v is not None
+            }
+            if "model" in done_meta:
+                done_meta["model_name"] = done_meta["model"]
+            response_metadata.update(done_meta)
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_ollama_stream(
+    raw: AsyncIterator[Any],
+    get_tool_calls: GetToolCalls,
+    *,
+    reasoning: bool | None = None,
+    message_id: str | None = None,
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_ollama_stream`.
+
+    `get_tool_calls` and the usage helper stay sync.
+    """
+    # Local import to avoid a circular import: `chat_models` imports this module.
+    from langchain_ollama.chat_models import (  # noqa: PLC0415
+        _get_usage_metadata_from_generation_info,
+    )
+
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "ollama"}
+    tool_idx = 0
+
+    async for resp in raw:
+        if not isinstance(resp, dict):
+            continue
+
+        message = resp.get("message") or {}
+
+        # Skip "load" responses with empty content, matching the compat bridge
+        # (`_aiterate_over_stream`): the model was loaded but generated nothing,
+        # so emitting an empty message-start/finish would diverge from the bridge.
+        content = message.get("content") or ""
+        if (
+            resp.get("done") is True
+            and resp.get("done_reason") == "load"
+            and not content.strip()
+        ):
+            continue
+
+        if not started:
+            started = True
+            yield _message_start(message_id, resp.get("model"))
+
+        thinking = message.get("thinking")
+        if reasoning and thinking:
+            for ev in tracker.feed(
+                _REASONING_KEY, {"type": "reasoning", "reasoning": thinking}
+            ):
+                yield ev
+
+        if content:
+            for ev in tracker.feed(_TEXT_KEY, {"type": "text", "text": content}):
+                yield ev
+
+        if message.get("tool_calls"):
+            for tc in get_tool_calls(resp):
+                for ev in tracker.feed(
+                    f"tool:{tool_idx}",
+                    {
+                        "type": "tool_call_chunk",
+                        "id": tc.get("id"),
+                        "name": tc.get("name"),
+                        "args": json.dumps(tc.get("args") or {}),
+                    },
+                ):
+                    yield ev
+                tool_idx += 1
+
+        if resp.get("done") is True:
+            usage = accumulate_usage(
+                usage, _get_usage_metadata_from_generation_info(resp)
+            )
+            done_meta = {
+                k: v for k, v in resp.items() if k != "message" and v is not None
+            }
+            if "model" in done_meta:
+                done_meta["model_name"] = done_meta["model"]
+            response_metadata.update(done_meta)
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)

--- a/libs/partners/ollama/langchain_ollama/chat_models.py
+++ b/libs/partners/ollama/langchain_ollama/chat_models.py
@@ -47,7 +47,7 @@ import logging
 import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from operator import itemgetter
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
@@ -96,6 +96,9 @@ from langchain_ollama._utils import (
     validate_model,
 )
 from langchain_ollama._version import __version__
+
+if TYPE_CHECKING:
+    from langchain_protocol.protocol import MessagesData
 
 log = logging.getLogger(__name__)
 
@@ -1307,6 +1310,45 @@ class ChatOllama(BaseChatModel):
                 )
             yield chunk
 
+    def _stream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[MessagesData]:
+        """Emit Ollama-native content-block protocol events.
+
+        Detected by `langchain-core`'s `_iter_v2_events`; powers
+        `stream_events(version="v3")`. Surfaces `thinking` as reasoning blocks,
+        which the compat-bridge path does not. `message_id` is threaded from the
+        stream so `message-start` matches the bridge's LangChain run id.
+        """
+        # Local import avoids a circular import: `_stream_events` imports
+        # `_get_usage_metadata_from_generation_info` from this module.
+        from langchain_ollama._stream_events import (  # noqa: PLC0415
+            convert_ollama_stream,
+        )
+
+        reasoning = kwargs.get("reasoning", self.reasoning)
+        for event in convert_ollama_stream(
+            self._create_chat_stream(messages, stop, **kwargs),
+            _get_tool_calls_from_response,
+            reasoning=reasoning,
+            message_id=message_id,
+        ):
+            if run_manager is not None and event["event"] == "content-block-delta":
+                # Widen to a plain dict for the optional `delta` access: TypedDict
+                # union narrowing on the discriminator differs across `ty`
+                # versions, so neither a typed key access nor a typed cast is
+                # portable here.
+                delta = cast("dict[str, Any]", event).get("delta") or {}
+                if delta.get("type") == "text-delta":
+                    run_manager.on_llm_new_token(str(delta.get("text", "")))
+            yield event
+
     async def _aiterate_over_stream(
         self,
         messages: list[BaseMessage],
@@ -1388,6 +1430,37 @@ class ChatOllama(BaseChatModel):
                     verbose=self.verbose,
                 )
             yield chunk
+
+    async def _astream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[MessagesData]:
+        """Async twin of `_stream_chat_model_events`."""
+        # Local import avoids a circular import: `_stream_events` imports
+        # `_get_usage_metadata_from_generation_info` from this module.
+        from langchain_ollama._stream_events import (  # noqa: PLC0415
+            aconvert_ollama_stream,
+        )
+
+        reasoning = kwargs.get("reasoning", self.reasoning)
+        async for event in aconvert_ollama_stream(
+            self._acreate_chat_stream(messages, stop, **kwargs),
+            _get_tool_calls_from_response,
+            reasoning=reasoning,
+            message_id=message_id,
+        ):
+            if run_manager is not None and event["event"] == "content-block-delta":
+                # See sync twin: widen to a plain dict for the optional `delta`
+                # access (portable across `ty` TypedDict-narrowing differences).
+                delta = cast("dict[str, Any]", event).get("delta") or {}
+                if delta.get("type") == "text-delta":
+                    await run_manager.on_llm_new_token(str(delta.get("text", "")))
+            yield event
 
     async def _agenerate(
         self,

--- a/libs/partners/ollama/tests/unit_tests/test_stream_events.py
+++ b/libs/partners/ollama/tests/unit_tests/test_stream_events.py
@@ -1,0 +1,244 @@
+"""Unit tests for the Ollama native stream-events converter."""
+
+from typing import Any, cast
+from unittest.mock import patch
+
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+from langchain_ollama import ChatOllama
+from langchain_ollama._stream_events import (
+    aconvert_ollama_stream,
+    convert_ollama_stream,
+)
+from langchain_ollama.chat_models import _get_tool_calls_from_response
+
+
+def _thinking_then_text_then_tool() -> list[dict]:
+    return [
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "", "thinking": "Let me "},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "", "thinking": "think."},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "The answer"},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": " is 42."},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "Paris"},
+                        }
+                    }
+                ],
+            },
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 10,
+            "eval_count": 7,
+        },
+    ]
+
+
+def test_convert_ollama_stream_lifecycle() -> None:
+    events: list[Any] = list(
+        convert_ollama_stream(
+            iter(_thinking_then_text_then_tool()),
+            _get_tool_calls_from_response,
+            reasoning=True,
+        )
+    )
+    assert_valid_event_stream(events)
+
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"] == ""  # empty → core's seeded run id stands
+    assert events[0]["metadata"]["provider"] == "ollama"
+
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    types = [f["content"]["type"] for f in finishes]
+    assert types == ["reasoning", "text", "tool_call"]
+    reasoning = cast("dict[str, Any]", finishes[0]["content"])
+    assert reasoning["reasoning"] == "Let me think."
+    text = cast("dict[str, Any]", finishes[1]["content"])
+    assert text["text"] == "The answer is 42."
+    tool = cast("dict[str, Any]", finishes[2]["content"])
+    assert tool["name"] == "get_weather"
+    assert tool["args"] == {"city": "Paris"}
+
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["usage"] == {
+        "input_tokens": 10,
+        "output_tokens": 7,
+        "total_tokens": 17,
+    }
+
+
+async def test_aconvert_ollama_stream_lifecycle() -> None:
+    async def _araw() -> Any:
+        for chunk in _thinking_then_text_then_tool():
+            yield chunk
+
+    events: list[Any] = [
+        ev
+        async for ev in aconvert_ollama_stream(
+            _araw(),
+            _get_tool_calls_from_response,
+            reasoning=True,
+        )
+    ]
+    assert_valid_event_stream(events)
+
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "ollama"
+
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    types = [f["content"]["type"] for f in finishes]
+    assert types == ["reasoning", "text", "tool_call"]
+    reasoning = cast("dict[str, Any]", finishes[0]["content"])
+    assert reasoning["reasoning"] == "Let me think."
+    text = cast("dict[str, Any]", finishes[1]["content"])
+    assert text["text"] == "The answer is 42."
+    tool = cast("dict[str, Any]", finishes[2]["content"])
+    assert tool["name"] == "get_weather"
+    assert tool["args"] == {"city": "Paris"}
+
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["usage"] == {
+        "input_tokens": 10,
+        "output_tokens": 7,
+        "total_tokens": 17,
+    }
+
+
+def test_convert_ollama_stream_reasoning_disabled() -> None:
+    """With reasoning off, thinking is not surfaced as a block."""
+    chunks = [
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "", "thinking": "hidden"},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "hi"},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        },
+    ]
+    events: list[Any] = list(
+        convert_ollama_stream(
+            iter(chunks), _get_tool_calls_from_response, reasoning=False
+        )
+    )
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == ["text"]
+
+
+def test_convert_ollama_stream_skips_leading_load_response() -> None:
+    """A leading `done_reason="load"` empty chunk is skipped, like the bridge."""
+    chunks = [
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "load",
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": "hi"},
+            "done": False,
+        },
+        {
+            "model": "qw3",
+            "message": {"role": "assistant", "content": ""},
+            "done": True,
+            "done_reason": "stop",
+            "prompt_eval_count": 1,
+            "eval_count": 1,
+        },
+    ]
+    events: list[Any] = list(
+        convert_ollama_stream(
+            iter(chunks), _get_tool_calls_from_response, reasoning=True
+        )
+    )
+    assert_valid_event_stream(events)
+    # message-start carries the model from the first *non-load* chunk, not the
+    # skipped load chunk, and the stream is not empty.
+    assert events[0]["event"] == "message-start"
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == ["text"]
+
+
+def test_ollama_stream_events_v3_model_level() -> None:
+    """End-to-end: `stream_events(version="v3")` drives the native hook."""
+    llm = ChatOllama(model="qw3", reasoning=True)
+    with patch.object(
+        ChatOllama,
+        "_create_chat_stream",
+        return_value=iter(_thinking_then_text_then_tool()),
+    ):
+        events: list[Any] = list(llm.stream_events("hi", version="v3"))
+
+    assert_valid_event_stream(events)
+    # message-start id is the LC run id (threaded by core), not empty.
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"]
+    finish_types = [
+        e["content"]["type"] for e in events if e["event"] == "content-block-finish"
+    ]
+    assert finish_types == ["reasoning", "text", "tool_call"]
+    assert events[-1]["metadata"]["model_provider"] == "ollama"
+
+
+async def test_ollama_astream_events_v3_model_level() -> None:
+    """Async end-to-end: `astream_events(version="v3")` drives the native hook."""
+
+    async def _araw() -> Any:
+        for chunk in _thinking_then_text_then_tool():
+            yield chunk
+
+    llm = ChatOllama(model="qw3", reasoning=True)
+    with patch.object(ChatOllama, "_acreate_chat_stream", return_value=_araw()):
+        stream = await llm.astream_events("hi", version="v3")
+        events: list[Any] = [ev async for ev in stream]
+
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"]
+    finish_types = [
+        e["content"]["type"] for e in events if e["event"] == "content-block-finish"
+    ]
+    assert finish_types == ["reasoning", "text", "tool_call"]
+    assert events[-1]["metadata"]["model_provider"] == "ollama"


### PR DESCRIPTION
> Stacked on #326 (core `BlockStreamTracker` + Anthropic), which it branches from. It depends only on the core primitive, not the OpenAI PRs, so it's a sibling of that chain rather than stacked behind it. Retargets to `master` once #326 lands.

Gives `ChatOllama` native `_stream_chat_model_events` / `_astream_chat_model_events` hooks so `stream_events(version="v3")` maps Ollama's raw stream directly to content-block events.

### The win over the bridge

Ollama's `_iterate_over_stream` puts reasoning in `additional_kwargs["reasoning_content"]` and content as a plain string, so the compat bridge **never surfaces reasoning as a content block**. The native converter maps the raw Ollama chunks directly — emitting real `reasoning` blocks (gated on `reasoning`, matching the existing flag), `text`, tool calls, and usage.

### How it works

A bespoke pure converter (`convert_ollama_stream` / async twin), mirroring the Anthropic converter, drives the raw Ollama chat stream into the shared `BlockStreamTracker`. `thinking` → `reasoning` blocks, `content` → `text`, complete `tool_calls` → finalized `tool_call` blocks, and final token counts → usage. It reuses Ollama's existing `_get_tool_calls_from_response` / `_get_usage_metadata_from_generation_info` helpers (injected). `message-start` carries the stream's LangChain run id (threaded from core), and `model_provider` is `"ollama"` — consistent with every other native path and the bridge. Load responses (`done_reason: "load"` with empty content) are skipped, matching the bridge.

### Worth careful review

- The bespoke block construction (Ollama gives string content, `additional_kwargs` reasoning, and complete — not streamed — tool calls), and the tool-call round-trip through the tracker's finalizer.
- Sync/async are faithful twins.
- Unit tests cover the lifecycle (reasoning/text/tool_call finish order + accumulated content + usage), reasoning-disabled, the load-response skip, and model-level `stream_events(version="v3")` end-to-end (sync + async).