### PR TITLE
feat(openai): provider-aware native streaming for compatible subclasses

### DIFF
--- a/libs/core/langchain_core/language_models/_compat_bridge.py
+++ b/libs/core/langchain_core/language_models/_compat_bridge.py
@@ -564,6 +564,75 @@ def _finalize_and_build_finish(
 
 
 # ---------------------------------------------------------------------------
+# Shared block-lifecycle tracker
+# ---------------------------------------------------------------------------
+
+
+class BlockStreamTracker:
+    """Allocate wire indices and emit content-block lifecycle events.
+
+    Single source of truth for the start/delta/accumulate/finalize
+    mechanics shared by the compat bridge and provider-native converters.
+    Source-side keys (a block's `index` field, int or str, or a
+    positional fallback) are mapped to sequential `uint` wire indices.
+    """
+
+    def __init__(self) -> None:
+        self._blocks: dict[Any, tuple[int, CompatBlock]] = {}
+        self._next_wire_idx = 0
+
+    def feed(self, key: Any, block: CompatBlock) -> Iterator[MessagesData]:
+        """Yield lifecycle events for a per-chunk block.
+
+        Yields `content-block-start` the first time `key` is seen, then
+        `content-block-delta` when the block carries fresh content,
+        accumulating per-index state for later finalization.
+        """
+        if key not in self._blocks:
+            wire_idx = self._next_wire_idx
+            self._next_wire_idx += 1
+            self._blocks[key] = (wire_idx, dict(block))
+            yield ContentBlockStartData(
+                event="content-block-start",
+                index=wire_idx,
+                content=_start_skeleton(block),
+            )
+        else:
+            wire_idx, existing = self._blocks[key]
+            self._blocks[key] = (wire_idx, _accumulate(existing, block))
+        if _should_emit_delta(block):
+            wire_idx, current = self._blocks[key]
+            is_block_delta = block.get("type") in (
+                "tool_call_chunk",
+                "server_tool_call_chunk",
+            )
+            delta_source = current if is_block_delta else block
+            yield ContentBlockDeltaData(
+                event="content-block-delta",
+                index=wire_idx,
+                delta=_to_content_delta(delta_source or block),
+            )
+
+    def finish_block(self, key: Any) -> Iterator[MessagesData]:
+        """Finalize and close one block at its true stop boundary.
+
+        Native converters call this on the provider's block-stop signal.
+        A no-op for unknown / already-closed keys.
+        """
+        entry = self._blocks.pop(key, None)
+        if entry is None:
+            return
+        wire_idx, block = entry
+        yield _finalize_and_build_finish(wire_idx, block)
+
+    def finish_all(self) -> Iterator[MessagesData]:
+        """Finalize every still-open block, in wire-index order."""
+        for wire_idx, block in self._blocks.values():
+            yield _finalize_and_build_finish(wire_idx, block)
+        self._blocks.clear()
+
+
+# ---------------------------------------------------------------------------
 # Main generators
 # ---------------------------------------------------------------------------
 
@@ -590,8 +659,7 @@ def chunks_to_events(
         `MessagesData` lifecycle events.
     """
     started = False
-    blocks: dict[Any, tuple[int, CompatBlock]] = {}
-    next_wire_idx = 0
+    tracker = BlockStreamTracker()
     usage: dict[str, Any] | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
@@ -633,30 +701,7 @@ def chunks_to_events(
             yield _build_message_start(msg, message_id)
 
         for key, block in _iter_protocol_blocks(msg):
-            if key not in blocks:
-                wire_idx = next_wire_idx
-                next_wire_idx += 1
-                blocks[key] = (wire_idx, dict(block))
-                yield ContentBlockStartData(
-                    event="content-block-start",
-                    index=wire_idx,
-                    content=_start_skeleton(block),
-                )
-            else:
-                wire_idx, existing = blocks[key]
-                blocks[key] = (wire_idx, _accumulate(existing, block))
-            if _should_emit_delta(block):
-                wire_idx, current = blocks[key]
-                is_block_delta = block.get("type") in (
-                    "tool_call_chunk",
-                    "server_tool_call_chunk",
-                )
-                delta_source = current if is_block_delta else block
-                yield ContentBlockDeltaData(
-                    event="content-block-delta",
-                    index=wire_idx,
-                    delta=_to_content_delta(delta_source or block),
-                )
+            yield from tracker.feed(key, block)
 
         if msg.usage_metadata:
             usage = _accumulate_usage(usage, msg.usage_metadata)
@@ -664,8 +709,7 @@ def chunks_to_events(
     if not started:
         return
 
-    for wire_idx, block in blocks.values():
-        yield _finalize_and_build_finish(wire_idx, block)
+    yield from tracker.finish_all()
 
     yield _build_message_finish(
         usage=usage,
@@ -681,8 +725,7 @@ async def achunks_to_events(
 ) -> AsyncIterator[MessagesData]:
     """Async variant of `chunks_to_events`."""
     started = False
-    blocks: dict[Any, tuple[int, CompatBlock]] = {}
-    next_wire_idx = 0
+    tracker = BlockStreamTracker()
     usage: dict[str, Any] | None = None
     response_metadata: dict[str, Any] = {}
     additional_kwargs: dict[str, Any] = {}
@@ -713,30 +756,8 @@ async def achunks_to_events(
             yield _build_message_start(msg, message_id)
 
         for key, block in _iter_protocol_blocks(msg):
-            if key not in blocks:
-                wire_idx = next_wire_idx
-                next_wire_idx += 1
-                blocks[key] = (wire_idx, dict(block))
-                yield ContentBlockStartData(
-                    event="content-block-start",
-                    index=wire_idx,
-                    content=_start_skeleton(block),
-                )
-            else:
-                wire_idx, existing = blocks[key]
-                blocks[key] = (wire_idx, _accumulate(existing, block))
-            if _should_emit_delta(block):
-                wire_idx, current = blocks[key]
-                is_block_delta = block.get("type") in (
-                    "tool_call_chunk",
-                    "server_tool_call_chunk",
-                )
-                delta_source = current if is_block_delta else block
-                yield ContentBlockDeltaData(
-                    event="content-block-delta",
-                    index=wire_idx,
-                    delta=_to_content_delta(delta_source or block),
-                )
+            for event in tracker.feed(key, block):
+                yield event
 
         if msg.usage_metadata:
             usage = _accumulate_usage(usage, msg.usage_metadata)
@@ -744,8 +765,8 @@ async def achunks_to_events(
     if not started:
         return
 
-    for wire_idx, block in blocks.values():
-        yield _finalize_and_build_finish(wire_idx, block)
+    for event in tracker.finish_all():
+        yield event
 
     yield _build_message_finish(
         usage=usage,
@@ -816,6 +837,7 @@ async def amessage_to_events(
 
 
 __all__ = [
+    "BlockStreamTracker",
     "CompatBlock",
     "achunks_to_events",
     "amessage_to_events",

--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -667,8 +667,16 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             getattr(self, "_stream_chat_model_events", None),
         )
         if native is not None:
+            # Thread the stream's message id (the LangChain run id) into the
+            # native producer so its `message-start` carries the same id the
+            # bridge path emits — keeping the two paths consistent for
+            # consumers that correlate v3 events by `message-start.id`.
             event_iter: Iterator[MessagesData] = native(
-                messages, stop=stop, run_manager=run_manager, **kwargs
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                message_id=stream.message_id,
+                **kwargs,
             )
         else:
             event_iter = chunks_to_events(
@@ -698,8 +706,14 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
             getattr(self, "_astream_chat_model_events", None),
         )
         if native is not None:
+            # See `_iter_v2_events`: thread the stream's message id into the
+            # native producer for `message-start` consistency with the bridge.
             event_iter: AsyncIterator[MessagesData] = native(
-                messages, stop=stop, run_manager=run_manager, **kwargs
+                messages,
+                stop=stop,
+                run_manager=run_manager,
+                message_id=stream.message_id,
+                **kwargs,
             )
         else:
             event_iter = achunks_to_events(

--- a/libs/core/langchain_core/language_models/stream_events.py
+++ b/libs/core/langchain_core/language_models/stream_events.py
@@ -1,0 +1,28 @@
+"""Shared primitives for provider-native streaming-event converters.
+
+Provider packages implementing `_stream_chat_model_events` import these
+to drive raw API events into the same content-block lifecycle the compat
+bridge produces, so native and bridged paths emit identical event shapes.
+"""
+
+from langchain_core.language_models._compat_bridge import (
+    BlockStreamTracker,
+    finalize_tool_call_chunk,
+)
+from langchain_core.language_models._compat_bridge import (
+    _accumulate_usage as accumulate_usage,
+)
+from langchain_core.language_models._compat_bridge import (
+    _build_message_finish as build_message_finish,
+)
+from langchain_core.language_models._compat_bridge import (
+    _iter_protocol_blocks as iter_protocol_blocks,
+)
+
+__all__ = [
+    "BlockStreamTracker",
+    "accumulate_usage",
+    "build_message_finish",
+    "finalize_tool_call_chunk",
+    "iter_protocol_blocks",
+]

--- a/libs/core/tests/unit_tests/language_models/test_block_stream_tracker.py
+++ b/libs/core/tests/unit_tests/language_models/test_block_stream_tracker.py
@@ -1,0 +1,65 @@
+"""Unit tests for the shared BlockStreamTracker."""
+
+from typing import Any
+
+from langchain_core.language_models.stream_events import BlockStreamTracker
+
+
+def test_feed_text_emits_start_then_delta() -> None:
+    tracker = BlockStreamTracker()
+    events: list[Any] = list(
+        tracker.feed(0, {"type": "text", "text": "Hi", "index": 0})
+    )
+    assert events[0]["event"] == "content-block-start"
+    assert events[0]["index"] == 0
+    assert events[0]["content"] == {"type": "text", "text": ""}
+    assert events[1]["event"] == "content-block-delta"
+    assert events[1]["index"] == 0
+    assert events[1]["delta"] == {"type": "text-delta", "text": "Hi"}
+
+
+def test_feed_allocates_sequential_wire_indices() -> None:
+    tracker = BlockStreamTracker()
+    list(tracker.feed("a", {"type": "text", "text": "x", "index": "a"}))
+    second: list[Any] = list(
+        tracker.feed("b", {"type": "text", "text": "y", "index": "b"})
+    )
+    assert second[0]["index"] == 1  # second distinct key -> wire index 1
+
+
+def test_finish_block_finalizes_tool_call_at_boundary() -> None:
+    tracker = BlockStreamTracker()
+    list(
+        tracker.feed(
+            0,
+            {
+                "type": "tool_call_chunk",
+                "id": "t1",
+                "name": "f",
+                "args": '{"a":',
+                "index": 0,
+            },
+        )
+    )
+    list(tracker.feed(0, {"type": "tool_call_chunk", "args": "1}", "index": 0}))
+    finished: list[Any] = list(tracker.finish_block(0))
+    assert len(finished) == 1
+    assert finished[0]["event"] == "content-block-finish"
+    assert finished[0]["content"]["type"] == "tool_call"
+    assert finished[0]["content"]["args"] == {"a": 1}
+    # finished block is closed: finish_all must not re-emit it
+    assert list(tracker.finish_all()) == []
+
+
+def test_finish_block_unknown_key_is_noop() -> None:
+    assert list(BlockStreamTracker().finish_block("nope")) == []
+
+
+def test_finish_all_finalizes_open_blocks_in_wire_order() -> None:
+    tracker = BlockStreamTracker()
+    list(tracker.feed(0, {"type": "text", "text": "hello", "index": 0}))
+    list(tracker.feed(1, {"type": "reasoning", "reasoning": "why", "index": 1}))
+    finished: list[Any] = list(tracker.finish_all())
+    assert [f["index"] for f in finished] == [0, 1]
+    assert finished[0]["content"]["text"] == "hello"
+    assert finished[1]["content"]["reasoning"] == "why"

--- a/libs/partners/anthropic/langchain_anthropic/_stream_events.py
+++ b/libs/partners/anthropic/langchain_anthropic/_stream_events.py
@@ -1,0 +1,147 @@
+"""Native content-block streaming-event converter for Anthropic.
+
+Maps the raw Anthropic SDK stream (``message_start`` /
+``content_block_start`` / ``content_block_delta`` / ``content_block_stop`` /
+``message_delta`` / ``message_stop``) to the protocol ``MessagesData``
+event lifecycle, reusing the shared ``BlockStreamTracker`` for block
+mechanics and the existing per-event chunk builder for content extraction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.language_models.stream_events import (
+    BlockStreamTracker,
+    accumulate_usage,
+    build_message_finish,
+    iter_protocol_blocks,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from langchain_core.messages import AIMessageChunk
+    from langchain_protocol.protocol import (
+        MessageMetadata,
+        MessagesData,
+        MessageStartData,
+    )
+
+# The bound method ``ChatAnthropic._make_message_chunk_from_anthropic_event``.
+MakeChunk = Callable[..., "tuple[AIMessageChunk | None, Any]"]
+
+
+def _message_start(event: Any, message_id: str | None) -> MessageStartData:
+    msg_obj = getattr(event, "message", None)
+    # Do not use the provider message id (`msg_...`) here: on the v3 path core
+    # seeds the stream with the LangChain run id, and an empty id lets that
+    # stand (matching the compat bridge). Only an explicit `message_id` wins.
+    resolved_id = message_id or ""
+    metadata: MessageMetadata = {"provider": "anthropic"}
+    model = getattr(msg_obj, "model", None)
+    if model:
+        metadata["model"] = model
+    return {
+        "event": "message-start",
+        "role": "ai",
+        "id": resolved_id,
+        "metadata": metadata,
+    }
+
+
+def convert_anthropic_stream(
+    raw: Iterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    stream_usage: bool = True,
+    message_id: str | None = None,
+) -> Iterator[MessagesData]:
+    """Convert a raw Anthropic event stream to protocol events.
+
+    Args:
+        raw: Raw Anthropic SDK stream events.
+        make_chunk: ``ChatAnthropic._make_message_chunk_from_anthropic_event``,
+            injected so the converter stays pure and unit-testable.
+        stream_usage: Forwarded to ``make_chunk``.
+        message_id: Overrides the provider message id on ``message-start``.
+
+    Yields:
+        Protocol ``MessagesData`` lifecycle events.
+    """
+    tracker = BlockStreamTracker()
+    started = False
+    block_start_event: Any = None
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "anthropic"}
+
+    for event in raw:
+        etype = getattr(event, "type", None)
+        chunk_msg, block_start_event = make_chunk(
+            event,
+            stream_usage=stream_usage,
+            coerce_content_to_string=False,
+            block_start_event=block_start_event,
+        )
+        if not started:
+            started = True
+            yield _message_start(event, message_id)
+        if chunk_msg is not None:
+            for key, block in iter_protocol_blocks(chunk_msg):
+                yield from tracker.feed(key, block)
+            if chunk_msg.usage_metadata:
+                usage = accumulate_usage(usage, chunk_msg.usage_metadata)
+            if chunk_msg.response_metadata:
+                response_metadata.update(chunk_msg.response_metadata)
+        if etype == "content_block_stop":
+            yield from tracker.finish_block(getattr(event, "index", None))
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_anthropic_stream(
+    raw: AsyncIterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    stream_usage: bool = True,
+    message_id: str | None = None,
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_anthropic_stream`. `make_chunk` is sync."""
+    tracker = BlockStreamTracker()
+    started = False
+    block_start_event: Any = None
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": "anthropic"}
+
+    async for event in raw:
+        etype = getattr(event, "type", None)
+        chunk_msg, block_start_event = make_chunk(
+            event,
+            stream_usage=stream_usage,
+            coerce_content_to_string=False,
+            block_start_event=block_start_event,
+        )
+        if not started:
+            started = True
+            yield _message_start(event, message_id)
+        if chunk_msg is not None:
+            for key, block in iter_protocol_blocks(chunk_msg):
+                for ev in tracker.feed(key, block):
+                    yield ev
+            if chunk_msg.usage_metadata:
+                usage = accumulate_usage(usage, chunk_msg.usage_metadata)
+            if chunk_msg.response_metadata:
+                response_metadata.update(chunk_msg.response_metadata)
+        if etype == "content_block_stop":
+            for ev in tracker.finish_block(getattr(event, "index", None)):
+                yield ev
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)

--- a/libs/partners/anthropic/langchain_anthropic/chat_models.py
+++ b/libs/partners/anthropic/langchain_anthropic/chat_models.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import AsyncIterator, Callable, Iterator, Mapping, Sequence
 from functools import cached_property
 from operator import itemgetter
-from typing import Any, Final, Literal, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 import anthropic
 from langchain_core.callbacks import (
@@ -64,8 +64,15 @@ from langchain_anthropic._client_utils import (
     _get_default_httpx_client,
 )
 from langchain_anthropic._compat import _convert_from_v1_to_anthropic
+from langchain_anthropic._stream_events import (
+    aconvert_anthropic_stream,
+    convert_anthropic_stream,
+)
 from langchain_anthropic.data._profiles import _PROFILES
 from langchain_anthropic.output_parsers import extract_tool_calls
+
+if TYPE_CHECKING:
+    from langchain_protocol.protocol import ContentBlockDelta, MessagesData
 
 _message_type_lookups = {
     "human": "user",
@@ -874,6 +881,13 @@ def _handle_anthropic_bad_request(e: anthropic.BadRequestError) -> None:
     raise
 
 
+def _delta_text_for_callback(delta: ContentBlockDelta) -> str:
+    """Text increment to report via `on_llm_new_token` (empty for non-text)."""
+    if delta.get("type") == "text-delta":
+        return cast("str", delta.get("text", ""))
+    return ""
+
+
 class ChatAnthropic(BaseChatModel):
     """Anthropic (Claude) chat models.
 
@@ -1506,6 +1520,74 @@ class ChatAnthropic(BaseChatModel):
                     if run_manager and isinstance(msg.content, str):
                         await run_manager.on_llm_new_token(msg.content, chunk=chunk)
                     yield chunk
+        except anthropic.BadRequestError as e:
+            _handle_anthropic_bad_request(e)
+
+    def _stream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        *,
+        stream_usage: bool | None = None,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[MessagesData]:
+        """Emit Anthropic-native content-block protocol events.
+
+        Detected by `langchain-core`'s `_iter_v2_events`; powers
+        `stream_events(version="v3")`. Falls through to the compat bridge
+        only if this method is absent. `message_id` is threaded from the
+        stream so `message-start` matches the bridge's LangChain run id.
+        """
+        if stream_usage is None:
+            stream_usage = self.stream_usage
+        kwargs["stream"] = True
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            raw = self._create(payload)
+            for event in convert_anthropic_stream(
+                raw,
+                self._make_message_chunk_from_anthropic_event,
+                stream_usage=stream_usage,
+                message_id=message_id,
+            ):
+                if run_manager is not None and event["event"] == "content-block-delta":
+                    token = _delta_text_for_callback(event["delta"])
+                    if token:
+                        run_manager.on_llm_new_token(token)
+                yield event
+        except anthropic.BadRequestError as e:
+            _handle_anthropic_bad_request(e)
+
+    async def _astream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        *,
+        stream_usage: bool | None = None,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[MessagesData]:
+        """Async twin of `_stream_chat_model_events`."""
+        if stream_usage is None:
+            stream_usage = self.stream_usage
+        kwargs["stream"] = True
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            raw = await self._acreate(payload)
+            async for event in aconvert_anthropic_stream(
+                raw,
+                self._make_message_chunk_from_anthropic_event,
+                stream_usage=stream_usage,
+                message_id=message_id,
+            ):
+                if run_manager is not None and event["event"] == "content-block-delta":
+                    token = _delta_text_for_callback(event["delta"])
+                    if token:
+                        await run_manager.on_llm_new_token(token)
+                yield event
         except anthropic.BadRequestError as e:
             _handle_anthropic_bad_request(e)
 

--- a/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_chat_models.py
@@ -3222,19 +3222,12 @@ def test_no_task_budget_no_beta() -> None:
         assert "task-budgets-2026-03-13" not in betas
 
 
-def test_anthropic_stream_events_v3_lifecycle() -> None:
-    """Validate lifecycle events across a thinking + text + tool_use stream.
+def _lifecycle_events() -> list[Any]:
+    """Build a raw thinking + text + tool_use Anthropic stream fixture.
 
-    Anthropic emits raw `content_block_start` / `content_block_delta` /
-    `content_block_stop` events with integer `index` fields, interleaved
-    with `message_start` and `message_delta`. This test threads a
-    realistic event sequence through `_stream` via a mocked raw client
-    and asserts that `stream_events(version="v3")` produces a spec-conformant
-    event stream: paired start/finish per block, no interleaving, sequential
-    `uint` wire indices.
+    Shared by the sync and async v3 lifecycle parity tests so both exercise
+    the identical event sequence through the native hooks.
     """
-    from unittest.mock import patch
-
     from anthropic.types import (
         InputJSONDelta,
         RawContentBlockDeltaEvent,
@@ -3252,7 +3245,6 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     from anthropic.types.raw_message_delta_event import (
         MessageDeltaUsage as RawMessageDeltaUsage,
     )
-    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 
     msg = Message(
         id="msg_1",
@@ -3265,7 +3257,7 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         type="message",
     )
 
-    events = [
+    return [
         RawMessageStartEvent(message=msg, type="message_start"),
         # thinking block (index=0)
         RawContentBlockStartEvent(
@@ -3337,6 +3329,24 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         RawMessageStopEvent(type="message_stop"),
     ]
 
+
+def test_anthropic_stream_events_v3_lifecycle() -> None:
+    """Validate lifecycle events across a thinking + text + tool_use stream.
+
+    Anthropic emits raw `content_block_start` / `content_block_delta` /
+    `content_block_stop` events with integer `index` fields, interleaved
+    with `message_start` and `message_delta`. This test threads a
+    realistic event sequence through `_stream` via a mocked raw client
+    and asserts that `stream_events(version="v3")` produces a spec-conformant
+    event stream: paired start/finish per block, no interleaving, sequential
+    `uint` wire indices.
+    """
+    from unittest.mock import patch
+
+    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+    events = _lifecycle_events()
+
     # Enable thinking so `coerce_content_to_string=False` in `_stream`,
     # which gives every content block an integer `index` field — the
     # structured path the protocol bridge actually exercises.  Default
@@ -3354,6 +3364,14 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
         stream_events = list(llm.stream_events("Test query", version="v3"))
 
     assert_valid_event_stream(stream_events)
+
+    # `message-start` must carry the stream's LangChain run id (threaded from
+    # core), matching the bridge path — not the provider message id ("msg_1")
+    # and not an empty string.
+    message_start = cast("dict[str, Any]", stream_events[0])
+    assert message_start["event"] == "message-start"
+    assert message_start["id"]
+    assert message_start["id"] != "msg_1"
 
     finishes = [e for e in stream_events if e["event"] == "content-block-finish"]
     types = [f["content"]["type"] for f in finishes]
@@ -3378,3 +3396,36 @@ def test_anthropic_stream_events_v3_lifecycle() -> None:
     message_finish = cast("dict[str, Any]", stream_events[-1])
     assert message_finish["event"] == "message-finish"
     assert message_finish["metadata"]["stop_reason"] == "tool_use"
+
+
+async def test_anthropic_astream_events_v3_lifecycle() -> None:
+    """Async twin of `test_anthropic_stream_events_v3_lifecycle`.
+
+    Exercises `_astream_chat_model_events` end-to-end via the
+    `AsyncChatModelStream` producer task.
+    """
+    from unittest.mock import patch
+
+    events = _lifecycle_events()
+    llm = ChatAnthropic(
+        model=MODEL_NAME, thinking={"type": "enabled", "budget_tokens": 1024}
+    )
+
+    async def mock_acreate(_payload: Any) -> Any:
+        async def _gen() -> Any:
+            for event in events:
+                yield event
+
+        return _gen()
+
+    with patch.object(llm, "_acreate", mock_acreate):
+        stream = await llm.astream_events("Test query", version="v3")
+        collected = [e async for e in stream]
+
+    finishes = [e for e in collected if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert collected[-1]["metadata"]["stop_reason"] == "tool_use"

--- a/libs/partners/anthropic/tests/unit_tests/test_stream_events.py
+++ b/libs/partners/anthropic/tests/unit_tests/test_stream_events.py
@@ -1,0 +1,182 @@
+"""Unit tests for the Anthropic native stream-events converter."""
+
+from typing import Any, cast
+
+from anthropic.types import (
+    InputJSONDelta,
+    Message,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
+    ToolUseBlock,
+    Usage,
+)
+from anthropic.types.raw_message_delta_event import Delta as RawMessageDelta
+from anthropic.types.raw_message_delta_event import (
+    MessageDeltaUsage as RawMessageDeltaUsage,
+)
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic._stream_events import convert_anthropic_stream
+
+MODEL_NAME = "claude-haiku-4-5-20251001"
+
+
+def _events() -> list[Any]:
+    msg = Message(
+        id="msg_1",
+        content=[],
+        model=MODEL_NAME,
+        role="assistant",
+        stop_reason=None,
+        stop_sequence=None,
+        usage=Usage(input_tokens=10, output_tokens=0),
+        type="message",
+    )
+    return [
+        RawMessageStartEvent(message=msg, type="message_start"),
+        RawContentBlockStartEvent(
+            content_block=ThinkingBlock(signature="", thinking="", type="thinking"),
+            index=0,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=ThinkingDelta(thinking="Let me ", type="thinking_delta"),
+            index=0,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=ThinkingDelta(thinking="think.", type="thinking_delta"),
+            index=0,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=0, type="content_block_stop"),
+        RawContentBlockStartEvent(
+            content_block=TextBlock(text="", type="text"),
+            index=1,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=TextDelta(text="The answer ", type="text_delta"),
+            index=1,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=TextDelta(text="is 42.", type="text_delta"),
+            index=1,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=1, type="content_block_stop"),
+        RawContentBlockStartEvent(
+            content_block=ToolUseBlock(
+                id="toolu_1", input={}, name="search", type="tool_use"
+            ),
+            index=2,
+            type="content_block_start",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=InputJSONDelta(partial_json='{"q":', type="input_json_delta"),
+            index=2,
+            type="content_block_delta",
+        ),
+        RawContentBlockDeltaEvent(
+            delta=InputJSONDelta(partial_json=' "weather"}', type="input_json_delta"),
+            index=2,
+            type="content_block_delta",
+        ),
+        RawContentBlockStopEvent(index=2, type="content_block_stop"),
+        RawMessageDeltaEvent(
+            delta=RawMessageDelta(stop_reason="tool_use", stop_sequence=None),
+            type="message_delta",
+            usage=RawMessageDeltaUsage(
+                output_tokens=50,
+                input_tokens=10,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        ),
+        RawMessageStopEvent(type="message_stop"),
+    ]
+
+
+def test_convert_anthropic_stream_lifecycle() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME)
+    events: list[Any] = list(
+        convert_anthropic_stream(
+            iter(_events()), llm._make_message_chunk_from_anthropic_event
+        )
+    )
+
+    assert_valid_event_stream(events)
+
+    assert events[0]["event"] == "message-start"
+    # The provider message id (`msg_1`) is deliberately NOT used: on the v3 path
+    # core seeds the stream with the LangChain run id, and an empty id here lets
+    # that stand (matching the compat bridge). Only an explicit `message_id`
+    # overrides it.
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "anthropic"
+    assert events[0]["metadata"]["model"] == MODEL_NAME
+
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert [f["index"] for f in finishes] == [0, 1, 2]
+    reasoning = cast("dict[str, Any]", finishes[0]["content"])
+    text = cast("dict[str, Any]", finishes[1]["content"])
+    assert reasoning["reasoning"] == "Let me think."
+    assert text["text"] == "The answer is 42."
+    tool = cast("dict[str, Any]", finishes[2]["content"])
+    assert tool["args"] == {"q": "weather"}
+    assert tool["name"] == "search"
+
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["metadata"]["stop_reason"] == "tool_use"
+    # content-block-finish for index 0 arrives before index 1 starts
+    # (true stop boundaries, not all-at-end).
+    first_finish = next(
+        i for i, e in enumerate(events) if e["event"] == "content-block-finish"
+    )
+    first_idx1_start = next(
+        i
+        for i, e in enumerate(events)
+        if e["event"] == "content-block-start" and e["index"] == 1
+    )
+    assert first_finish < first_idx1_start
+
+
+async def test_aconvert_anthropic_stream_lifecycle() -> None:
+    llm = ChatAnthropic(model=MODEL_NAME)
+
+    async def _araw() -> Any:
+        for event in _events():
+            yield event
+
+    from langchain_anthropic._stream_events import aconvert_anthropic_stream
+
+    events: list[Any] = [
+        e
+        async for e in aconvert_anthropic_stream(
+            _araw(), llm._make_message_chunk_from_anthropic_event
+        )
+    ]
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == [
+        "reasoning",
+        "text",
+        "tool_call",
+    ]
+    assert events[-1]["metadata"]["stop_reason"] == "tool_use"

--- a/libs/partners/deepseek/langchain_deepseek/chat_models.py
+++ b/libs/partners/deepseek/langchain_deepseek/chat_models.py
@@ -339,6 +339,10 @@ class ChatDeepSeek(BaseChatOpenAI):
 
         return rtn
 
+    @property
+    def _stream_event_provider(self) -> str:
+        return "deepseek"
+
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,

--- a/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/deepseek/tests/unit_tests/test_chat_models.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from typing import Any, Literal
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from langchain_core.messages import AIMessageChunk, ToolMessage
 from langchain_tests.unit_tests import ChatModelUnitTests
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 from openai import BaseModel
 from openai.types.chat import ChatCompletionMessage
 from pydantic import BaseModel as PydanticBaseModel
 from pydantic import Field, SecretStr
+from typing_extensions import Self
 
 from langchain_deepseek.chat_models import DEFAULT_API_BASE, ChatDeepSeek
 
@@ -447,3 +449,63 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-deepseek" in versions
     assert "langchain-openai" in versions
+
+
+class _MockSyncContextManager:
+    """Minimal context manager yielding OpenAI-shaped completions chunks."""
+
+    def __init__(self, chunks: list[dict[str, Any]]) -> None:
+        self._chunks = iter(chunks)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> dict[str, Any]:
+        return next(self._chunks)
+
+
+def test_deepseek_stream_events_v3_provider_label() -> None:
+    """DeepSeek's native v3 stream labels `model_provider` as 'deepseek'."""
+    # Minimal OpenAI-shaped completions chunks (deepseek uses the openai client).
+    chunks: list[dict[str, Any]] = [
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "hi"},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+    ]
+
+    llm = ChatDeepSeek(model=MODEL_NAME, api_key=SecretStr("x"))
+    mock_client = MagicMock()
+
+    def mock_create(*_args: Any, **_kwargs: Any) -> _MockSyncContextManager:
+        return _MockSyncContextManager(chunks)
+
+    mock_client.create = mock_create
+    with patch.object(llm, "client", mock_client):
+        events: list[Any] = list(llm.stream_events("hi", version="v3"))
+
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[0]["metadata"]["provider"] == "deepseek"
+    assert events[-1]["event"] == "message-finish"
+    assert events[-1]["metadata"]["model_provider"] == "deepseek"

--- a/libs/partners/openai/langchain_openai/__init__.py
+++ b/libs/partners/openai/langchain_openai/__init__.py
@@ -3,6 +3,10 @@
 from langchain_openai._version import __version__
 from langchain_openai.chat_models import AzureChatOpenAI, ChatOpenAI
 from langchain_openai.chat_models._client_utils import StreamChunkTimeoutError
+from langchain_openai.chat_models._stream_events import (
+    aconvert_openai_completions_stream,
+    convert_openai_completions_stream,
+)
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
 from langchain_openai.llms import AzureOpenAI, OpenAI
 from langchain_openai.tools import custom_tool
@@ -16,5 +20,7 @@ __all__ = [
     "OpenAIEmbeddings",
     "StreamChunkTimeoutError",
     "__version__",
+    "aconvert_openai_completions_stream",
+    "convert_openai_completions_stream",
     "custom_tool",
 ]

--- a/libs/partners/openai/langchain_openai/__init__.py
+++ b/libs/partners/openai/langchain_openai/__init__.py
@@ -5,7 +5,9 @@ from langchain_openai.chat_models import AzureChatOpenAI, ChatOpenAI
 from langchain_openai.chat_models._client_utils import StreamChunkTimeoutError
 from langchain_openai.chat_models._stream_events import (
     aconvert_openai_completions_stream,
+    aconvert_openai_responses_stream,
     convert_openai_completions_stream,
+    convert_openai_responses_stream,
 )
 from langchain_openai.embeddings import AzureOpenAIEmbeddings, OpenAIEmbeddings
 from langchain_openai.llms import AzureOpenAI, OpenAI
@@ -21,6 +23,8 @@ __all__ = [
     "StreamChunkTimeoutError",
     "__version__",
     "aconvert_openai_completions_stream",
+    "aconvert_openai_responses_stream",
     "convert_openai_completions_stream",
+    "convert_openai_responses_stream",
     "custom_tool",
 ]

--- a/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
@@ -1,0 +1,162 @@
+"""Native content-block streaming-event converter for OpenAI Chat Completions.
+
+Drives raw OpenAI Chat Completions chunks into the shared `BlockStreamTracker`,
+reusing `BaseChatOpenAI._convert_chunk_to_generation_chunk` for content
+extraction (it already yields indexed content blocks + tool-call chunks). This
+converter is the reuse seam for OpenAI-compatible providers (deepseek, groq,
+fireworks, xai, openrouter), which adapt their chunk shape to OpenAI's and call
+it with a different `provider`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.language_models.stream_events import (
+    BlockStreamTracker,
+    accumulate_usage,
+    build_message_finish,
+    iter_protocol_blocks,
+)
+from langchain_core.messages import AIMessageChunk
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from langchain_core.outputs import ChatGenerationChunk
+    from langchain_protocol.protocol import (
+        MessageMetadata,
+        MessagesData,
+        MessageStartData,
+    )
+
+# Bound `BaseChatOpenAI._convert_chunk_to_generation_chunk`.
+MakeChunk = Callable[..., "ChatGenerationChunk | None"]
+
+
+def _message_start(
+    message_id: str | None, model: str | None, provider: str
+) -> MessageStartData:
+    metadata: MessageMetadata = {"provider": provider}
+    if model:
+        metadata["model"] = model
+    return {
+        "event": "message-start",
+        "role": "ai",
+        "id": message_id or "",
+        "metadata": metadata,
+    }
+
+
+def convert_openai_completions_stream(
+    raw: Iterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    base_generation_info: dict[str, Any] | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> Iterator[MessagesData]:
+    """Convert a raw OpenAI Chat Completions chunk stream to protocol events.
+
+    Args:
+        raw: Raw OpenAI chunks (dicts or SDK objects with `model_dump`).
+        make_chunk: `BaseChatOpenAI._convert_chunk_to_generation_chunk`, injected
+            so the converter stays pure and unit-testable.
+        base_generation_info: Passed to `make_chunk` for the first chunk only
+            (mirrors `_stream`), `{}` thereafter.
+        message_id: Message id for `message-start`. Left empty by default so
+            the v3 stream's seeded LangChain run id stands (matching the compat
+            bridge); the provider completion id is deliberately not used here.
+        provider: `model_provider` id for downstream reuse (groq, deepseek, ...).
+
+    Yields:
+        Protocol `MessagesData` lifecycle events.
+    """
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    first = True
+
+    for chunk in raw:
+        if not isinstance(chunk, dict):
+            chunk = chunk.model_dump()
+        if model is None and chunk.get("model"):
+            model = chunk["model"]
+        gen = make_chunk(chunk, AIMessageChunk, base_generation_info if first else {})
+        first = False
+        if gen is None:
+            continue
+        msg = gen.message
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        for key, block in iter_protocol_blocks(msg):
+            yield from tracker.feed(key, block)
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
+            # `_convert_chunk_to_generation_chunk` hardcodes
+            # `model_provider="openai"`; re-apply the caller's `provider` so
+            # OpenAI-compatible reuse (groq, deepseek, ...) isn't mislabeled.
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_openai_completions_stream(
+    raw: AsyncIterator[Any],
+    make_chunk: MakeChunk,
+    *,
+    base_generation_info: dict[str, Any] | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_openai_completions_stream`. `make_chunk` is sync."""
+    tracker = BlockStreamTracker()
+    started = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    first = True
+
+    async for chunk in raw:
+        if not isinstance(chunk, dict):
+            chunk = chunk.model_dump()
+        if model is None and chunk.get("model"):
+            model = chunk["model"]
+        gen = make_chunk(chunk, AIMessageChunk, base_generation_info if first else {})
+        first = False
+        if gen is None:
+            continue
+        msg = gen.message
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        for key, block in iter_protocol_blocks(msg):
+            for ev in tracker.feed(key, block):
+                yield ev
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
+            # `_convert_chunk_to_generation_chunk` hardcodes
+            # `model_provider="openai"`; re-apply the caller's `provider` so
+            # OpenAI-compatible reuse (groq, deepseek, ...) isn't mislabeled.
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)

--- a/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
+++ b/libs/partners/openai/langchain_openai/chat_models/_stream_events.py
@@ -34,6 +34,13 @@ if TYPE_CHECKING:
 # Bound `BaseChatOpenAI._convert_chunk_to_generation_chunk`.
 MakeChunk = Callable[..., "ChatGenerationChunk | None"]
 
+# Bound `_convert_responses_chunk_to_generation_chunk`:
+# (chunk, idx, out_idx, sub_idx, *, schema, metadata, has_reasoning, output_version)
+#   -> (idx, out_idx, sub_idx, ChatGenerationChunk | None)
+ConvertResponsesChunk = Callable[
+    ..., "tuple[int, int, int, ChatGenerationChunk | None]"
+]
+
 
 def _message_start(
     message_id: str | None, model: str | None, provider: str
@@ -153,6 +160,159 @@ async def aconvert_openai_completions_stream(
             # `_convert_chunk_to_generation_chunk` hardcodes
             # `model_provider="openai"`; re-apply the caller's `provider` so
             # OpenAI-compatible reuse (groq, deepseek, ...) isn't mislabeled.
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    for ev in tracker.finish_all():
+        yield ev
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+def convert_openai_responses_stream(
+    raw: Iterator[Any],
+    convert_chunk: ConvertResponsesChunk,
+    *,
+    schema: Any = None,
+    output_version: str | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> Iterator[MessagesData]:
+    """Convert a raw OpenAI Responses API event stream to protocol events.
+
+    Reuses `_convert_responses_chunk_to_generation_chunk` (injected as
+    `convert_chunk` to avoid a circular import) for per-event content, threading
+    its index state. Emits true `content-block-finish` boundaries by closing the
+    open block when the monotonic `current_index` advances.
+
+    Args:
+        raw: Raw Responses API events.
+        convert_chunk: `_convert_responses_chunk_to_generation_chunk`.
+        schema: `response_format` schema, forwarded to `convert_chunk`.
+        output_version: `self.output_version`, forwarded to `convert_chunk`.
+        message_id: Left empty by default so the v3 stream's seeded run id stands.
+        provider: `model_provider` id for downstream reuse.
+
+    Yields:
+        Protocol `MessagesData` lifecycle events.
+    """
+    tracker = BlockStreamTracker()
+    started = False
+    current_index = current_output_index = current_sub_index = -1
+    has_reasoning = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    open_index: Any = None
+
+    for chunk in raw:
+        (
+            current_index,
+            current_output_index,
+            current_sub_index,
+            gen,
+        ) = convert_chunk(
+            chunk,
+            current_index,
+            current_output_index,
+            current_sub_index,
+            schema=schema,
+            metadata={},
+            has_reasoning=has_reasoning,
+            output_version=output_version,
+        )
+        if gen is None:
+            continue
+        msg = gen.message
+        if model is None:
+            model = (msg.response_metadata or {}).get("model_name") or (
+                msg.response_metadata or {}
+            ).get("model")
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        if "reasoning" in msg.additional_kwargs:
+            has_reasoning = True
+        for key, block in iter_protocol_blocks(msg):
+            if open_index is not None and key != open_index:
+                # Monotonic index advanced: the previous block is complete.
+                yield from tracker.finish_block(open_index)
+            yield from tracker.feed(key, block)
+            open_index = key
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
+            response_metadata["model_provider"] = provider
+
+    if not started:
+        return
+    yield from tracker.finish_all()
+    yield build_message_finish(usage=usage, response_metadata=response_metadata)
+
+
+async def aconvert_openai_responses_stream(
+    raw: AsyncIterator[Any],
+    convert_chunk: ConvertResponsesChunk,
+    *,
+    schema: Any = None,
+    output_version: str | None = None,
+    message_id: str | None = None,
+    provider: str = "openai",
+) -> AsyncIterator[MessagesData]:
+    """Async twin of `convert_openai_responses_stream`. `convert_chunk` is sync."""
+    tracker = BlockStreamTracker()
+    started = False
+    current_index = current_output_index = current_sub_index = -1
+    has_reasoning = False
+    usage: dict[str, Any] | None = None
+    response_metadata: dict[str, Any] = {"model_provider": provider}
+    model: str | None = None
+    open_index: Any = None
+
+    async for chunk in raw:
+        (
+            current_index,
+            current_output_index,
+            current_sub_index,
+            gen,
+        ) = convert_chunk(
+            chunk,
+            current_index,
+            current_output_index,
+            current_sub_index,
+            schema=schema,
+            metadata={},
+            has_reasoning=has_reasoning,
+            output_version=output_version,
+        )
+        if gen is None:
+            continue
+        msg = gen.message
+        if model is None:
+            model = (msg.response_metadata or {}).get("model_name") or (
+                msg.response_metadata or {}
+            ).get("model")
+        if not started:
+            started = True
+            yield _message_start(message_id, model, provider)
+        if "reasoning" in msg.additional_kwargs:
+            has_reasoning = True
+        for key, block in iter_protocol_blocks(msg):
+            if open_index is not None and key != open_index:
+                for ev in tracker.finish_block(open_index):
+                    yield ev
+            for ev in tracker.feed(key, block):
+                yield ev
+            open_index = key
+        usage_metadata = getattr(msg, "usage_metadata", None)
+        if usage_metadata:
+            usage = accumulate_usage(usage, usage_metadata)
+        merged = {**(gen.generation_info or {}), **(msg.response_metadata or {})}
+        if merged:
+            response_metadata.update(merged)
             response_metadata["model_provider"] = provider
 
     if not started:

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -155,7 +155,9 @@ from langchain_openai.chat_models._compat import (
 )
 from langchain_openai.chat_models._stream_events import (
     aconvert_openai_completions_stream,
+    aconvert_openai_responses_stream,
     convert_openai_completions_stream,
+    convert_openai_responses_stream,
 )
 from langchain_openai.data._profiles import _PROFILES
 
@@ -1929,22 +1931,24 @@ class BaseChatOpenAI(BaseChatModel):
         message_id: str | None = None,
         **kwargs: Any,
     ) -> Iterator[MessagesData]:
-        """Emit OpenAI-native content-block events for the Chat Completions path.
+        """Emit OpenAI-native content-block events for Completions and Responses.
 
-        Defers to the compat bridge for cases this converter does not yet
-        specialize: the Responses API, structured output (`response_format`),
-        and raw-header mode. Detected by core's `_iter_v2_events`.
+        The standard Completions and Responses API paths run through their
+        native converters. Structured output (`response_format`) and raw-header
+        mode still defer to the compat bridge over `_stream`, since those keep
+        the final-completion handling only `_stream` performs. Detected by
+        core's `_iter_v2_events`.
         """
-        # Responses API / structured output / raw headers: bridge over `_stream`,
-        # which (on `ChatOpenAI`) routes to the Responses path when applicable.
+        use_responses = self._use_responses_api({**kwargs, **self.model_kwargs})
         # `response_format` may arrive via call kwargs or be baked into
         # `model_kwargs`; both fold into the payload, so check both.
-        if (
-            self._use_responses_api({**kwargs, **self.model_kwargs})
-            or kwargs.get("response_format") is not None
+        has_response_format = (
+            kwargs.get("response_format") is not None
             or self.model_kwargs.get("response_format") is not None
-            or self.include_response_headers
-        ):
+        )
+        # Structured output and raw-header mode keep the post-loop /
+        # final-completion handling that only `_stream` performs — defer those.
+        if has_response_format or self.include_response_headers:
             # Forward kwargs untouched (as core's `_iter_v2_events` would):
             # `_stream` handles `stream_usage` itself, and the Responses path
             # rejects a stray `stream_usage` kwarg, so we must not inject one.
@@ -1957,6 +1961,35 @@ class BaseChatOpenAI(BaseChatModel):
                 ),
                 message_id=message_id,
             )
+            return
+        if use_responses:
+            self._ensure_sync_client_available()
+            kwargs["stream"] = True
+            payload = self._get_request_payload(messages, stop=stop, **kwargs)
+            try:
+                with self.root_client.responses.create(**payload) as response:
+                    for event in convert_openai_responses_stream(
+                        response,
+                        _convert_responses_chunk_to_generation_chunk,
+                        # Always None here: the `response_format` (structured
+                        # output) path is handled by the bridge branch above.
+                        schema=None,
+                        output_version=self.output_version,
+                        message_id=message_id,
+                    ):
+                        if (
+                            run_manager is not None
+                            and event["event"] == "content-block-delta"
+                            and event["delta"].get("type") == "text-delta"
+                        ):
+                            run_manager.on_llm_new_token(
+                                str(event["delta"].get("text", ""))
+                            )
+                        yield event
+            except openai.BadRequestError as e:
+                _handle_openai_bad_request(e)
+            except openai.APIError as e:
+                _handle_openai_api_error(e)
             return
 
         self._ensure_sync_client_available()
@@ -2001,12 +2034,14 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> AsyncIterator[MessagesData]:
         """Async twin of `_stream_chat_model_events`."""
-        if (
-            self._use_responses_api({**kwargs, **self.model_kwargs})
-            or kwargs.get("response_format") is not None
+        use_responses = self._use_responses_api({**kwargs, **self.model_kwargs})
+        has_response_format = (
+            kwargs.get("response_format") is not None
             or self.model_kwargs.get("response_format") is not None
-            or self.include_response_headers
-        ):
+        )
+        # Structured output and raw-header mode keep the post-loop /
+        # final-completion handling that only `_astream` performs — defer those.
+        if has_response_format or self.include_response_headers:
             # Forward kwargs untouched (as core's `_aiter_v2_events` would):
             # `_astream` handles `stream_usage` itself, and the Responses path
             # rejects a stray `stream_usage` kwarg, so we must not inject one.
@@ -2020,6 +2055,42 @@ class BaseChatOpenAI(BaseChatModel):
                 message_id=message_id,
             ):
                 yield event
+            return
+        if use_responses:
+            kwargs["stream"] = True
+            payload = self._get_request_payload(messages, stop=stop, **kwargs)
+            try:
+                response = await self.root_async_client.responses.create(**payload)
+                async with response as stream:
+                    # Mirror `_astream_responses`: apply per-chunk stall
+                    # protection before the converter consumes the stream.
+                    timed_stream = _astream_with_chunk_timeout(
+                        stream,
+                        self.stream_chunk_timeout,
+                        model_name=self.model_name,
+                    )
+                    async for event in aconvert_openai_responses_stream(
+                        timed_stream,
+                        _convert_responses_chunk_to_generation_chunk,
+                        # Always None here: the `response_format` (structured
+                        # output) path is handled by the bridge branch above.
+                        schema=None,
+                        output_version=self.output_version,
+                        message_id=message_id,
+                    ):
+                        if (
+                            run_manager is not None
+                            and event["event"] == "content-block-delta"
+                            and event["delta"].get("type") == "text-delta"
+                        ):
+                            await run_manager.on_llm_new_token(
+                                str(event["delta"].get("text", ""))
+                            )
+                        yield event
+            except openai.BadRequestError as e:
+                _handle_openai_bad_request(e)
+            except openai.APIError as e:
+                _handle_openai_api_error(e)
             return
 
         kwargs["stream"] = True

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -56,6 +56,10 @@ from langchain_core.language_models import (
     LanguageModelInput,
     ModelProfileRegistry,
 )
+from langchain_core.language_models._compat_bridge import (
+    achunks_to_events,
+    chunks_to_events,
+)
 from langchain_core.language_models.chat_models import (
     BaseChatModel,
     LangSmithParams,
@@ -149,11 +153,16 @@ from langchain_openai.chat_models._compat import (
     _convert_from_v1_to_responses,
     _convert_to_v03_ai_message,
 )
+from langchain_openai.chat_models._stream_events import (
+    aconvert_openai_completions_stream,
+    convert_openai_completions_stream,
+)
 from langchain_openai.data._profiles import _PROFILES
 
 if TYPE_CHECKING:
     import httpx
     from langchain_core.language_models import ModelProfile
+    from langchain_protocol.protocol import MessagesData
     from openai.types.responses import Response
 
 logger = logging.getLogger(__name__)
@@ -1910,6 +1919,147 @@ class BaseChatOpenAI(BaseChatModel):
                     generation_chunk.text, chunk=generation_chunk
                 )
             yield generation_chunk
+
+    def _stream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> Iterator[MessagesData]:
+        """Emit OpenAI-native content-block events for the Chat Completions path.
+
+        Defers to the compat bridge for cases this converter does not yet
+        specialize: the Responses API, structured output (`response_format`),
+        and raw-header mode. Detected by core's `_iter_v2_events`.
+        """
+        # Responses API / structured output / raw headers: bridge over `_stream`,
+        # which (on `ChatOpenAI`) routes to the Responses path when applicable.
+        # `response_format` may arrive via call kwargs or be baked into
+        # `model_kwargs`; both fold into the payload, so check both.
+        if (
+            self._use_responses_api({**kwargs, **self.model_kwargs})
+            or kwargs.get("response_format") is not None
+            or self.model_kwargs.get("response_format") is not None
+            or self.include_response_headers
+        ):
+            # Forward kwargs untouched (as core's `_iter_v2_events` would):
+            # `_stream` handles `stream_usage` itself, and the Responses path
+            # rejects a stray `stream_usage` kwarg, so we must not inject one.
+            yield from chunks_to_events(
+                self._stream(
+                    messages,
+                    stop=stop,
+                    run_manager=run_manager,
+                    **kwargs,
+                ),
+                message_id=message_id,
+            )
+            return
+
+        self._ensure_sync_client_available()
+        kwargs["stream"] = True
+        stream_usage = self._should_stream_usage(
+            kwargs.pop("stream_usage", None), **kwargs
+        )
+        if stream_usage:
+            kwargs["stream_options"] = {"include_usage": stream_usage}
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            with self.client.create(**payload) as response:
+                for event in convert_openai_completions_stream(
+                    response,
+                    self._convert_chunk_to_generation_chunk,
+                    message_id=message_id,
+                ):
+                    if (
+                        run_manager is not None
+                        and event["event"] == "content-block-delta"
+                        and event["delta"].get("type") == "text-delta"
+                    ):
+                        # Text-only by design on the v3 events path: the events
+                        # themselves carry block/usage detail, so the legacy
+                        # `chunk=`/`logprobs=` callback args are not threaded.
+                        run_manager.on_llm_new_token(
+                            str(event["delta"].get("text", ""))
+                        )
+                    yield event
+        except openai.BadRequestError as e:
+            _handle_openai_bad_request(e)
+        except openai.APIError as e:
+            _handle_openai_api_error(e)
+
+    async def _astream_chat_model_events(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: AsyncCallbackManagerForLLMRun | None = None,
+        *,
+        message_id: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[MessagesData]:
+        """Async twin of `_stream_chat_model_events`."""
+        if (
+            self._use_responses_api({**kwargs, **self.model_kwargs})
+            or kwargs.get("response_format") is not None
+            or self.model_kwargs.get("response_format") is not None
+            or self.include_response_headers
+        ):
+            # Forward kwargs untouched (as core's `_aiter_v2_events` would):
+            # `_astream` handles `stream_usage` itself, and the Responses path
+            # rejects a stray `stream_usage` kwarg, so we must not inject one.
+            async for event in achunks_to_events(
+                self._astream(
+                    messages,
+                    stop=stop,
+                    run_manager=run_manager,
+                    **kwargs,
+                ),
+                message_id=message_id,
+            ):
+                yield event
+            return
+
+        kwargs["stream"] = True
+        stream_usage = self._should_stream_usage(
+            kwargs.pop("stream_usage", None), **kwargs
+        )
+        if stream_usage:
+            kwargs["stream_options"] = {"include_usage": stream_usage}
+        payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        try:
+            response = await self.async_client.create(**payload)
+            async with response as stream:
+                # Mirror `_astream`: apply per-chunk stall protection before the
+                # converter consumes the stream.
+                timed_stream = _astream_with_chunk_timeout(
+                    stream,
+                    self.stream_chunk_timeout,
+                    model_name=self.model_name,
+                )
+                async for event in aconvert_openai_completions_stream(
+                    timed_stream,
+                    self._convert_chunk_to_generation_chunk,
+                    message_id=message_id,
+                ):
+                    if (
+                        run_manager is not None
+                        and event["event"] == "content-block-delta"
+                        and event["delta"].get("type") == "text-delta"
+                    ):
+                        # Text-only by design on the v3 events path: the events
+                        # themselves carry block/usage detail, so the legacy
+                        # `chunk=`/`logprobs=` callback args are not threaded.
+                        await run_manager.on_llm_new_token(
+                            str(event["delta"].get("text", ""))
+                        )
+                    yield event
+        except openai.BadRequestError as e:
+            _handle_openai_bad_request(e)
+        except openai.APIError as e:
+            _handle_openai_api_error(e)
 
     async def _agenerate(
         self,

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1922,6 +1922,16 @@ class BaseChatOpenAI(BaseChatModel):
                 )
             yield generation_chunk
 
+    @property
+    def _stream_event_provider(self) -> str:
+        """`model_provider` id emitted by the native streaming-event hooks.
+
+        Overridden by OpenAI-compatible subclasses (e.g. `ChatDeepSeek`,
+        `ChatXAI`) so their native `stream_events(version="v3")` output is
+        labeled with the correct provider instead of `"openai"`.
+        """
+        return "openai"
+
     def _stream_chat_model_events(
         self,
         messages: list[BaseMessage],
@@ -1976,6 +1986,7 @@ class BaseChatOpenAI(BaseChatModel):
                         schema=None,
                         output_version=self.output_version,
                         message_id=message_id,
+                        provider=self._stream_event_provider,
                     ):
                         if (
                             run_manager is not None
@@ -2006,6 +2017,7 @@ class BaseChatOpenAI(BaseChatModel):
                     response,
                     self._convert_chunk_to_generation_chunk,
                     message_id=message_id,
+                    provider=self._stream_event_provider,
                 ):
                     if (
                         run_manager is not None
@@ -2077,6 +2089,7 @@ class BaseChatOpenAI(BaseChatModel):
                         schema=None,
                         output_version=self.output_version,
                         message_id=message_id,
+                        provider=self._stream_event_provider,
                     ):
                         if (
                             run_manager is not None
@@ -2114,6 +2127,7 @@ class BaseChatOpenAI(BaseChatModel):
                     timed_stream,
                     self._convert_chunk_to_generation_chunk,
                     message_id=message_id,
+                    provider=self._stream_event_provider,
                 ):
                     if (
                         run_manager is not None

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -635,11 +635,36 @@ def test_openai_stream_events_v3_lifecycle(mock_openai_completion: list) -> None
         events = list(llm.stream_events("你的名字叫什么？只回答名字", version="v3"))
 
     assert_valid_event_stream(events)
+    # `message-start` carries the stream's LangChain run id (threaded from core),
+    # not the provider completion id and not an empty string.
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"]
+    assert not events[0]["id"].startswith("chatcmpl")
     # At minimum, a text block with the accumulated answer.
     finishes = [e for e in events if e["event"] == "content-block-finish"]
     assert len(finishes) >= 1
     text_finishes = [f for f in finishes if f["content"]["type"] == "text"]
     assert len(text_finishes) == 1
+
+
+async def test_openai_astream_events_v3_lifecycle(mock_openai_completion: list) -> None:
+    """Async twin of `test_openai_stream_events_v3_lifecycle`."""
+    from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    mock_client = MagicMock()
+
+    async def mock_acreate(*args: Any, **kwargs: Any) -> MockAsyncContextManager:
+        return MockAsyncContextManager(mock_openai_completion)
+
+    mock_client.create = mock_acreate
+    with patch.object(llm, "async_client", mock_client):
+        stream = await llm.astream_events("test", version="v3")
+        events = [e async for e in stream]
+
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert len([f for f in finishes if f["content"]["type"] == "text"]) == 1
 
 
 @pytest.fixture

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream.py
@@ -46,7 +46,10 @@ from openai.types.shared.reasoning import Reasoning
 from openai.types.shared.response_format_text import ResponseFormatText
 
 from langchain_openai import ChatOpenAI
-from tests.unit_tests.chat_models.test_base import MockSyncContextManager
+from tests.unit_tests.chat_models.test_base import (
+    MockAsyncContextManager,
+    MockSyncContextManager,
+)
 
 MODEL = "gpt-5.4"
 
@@ -783,6 +786,12 @@ def test_responses_stream_events_v3_emits_reasoning_lifecycle() -> None:
 
     assert_valid_event_stream(events)
 
+    # `message-start` carries the stream's LangChain run id (threaded from core),
+    # not the provider response id and not an empty string.
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"]
+    assert not events[0]["id"].startswith("resp")
+
     reasoning_starts = [
         e
         for e in events
@@ -809,6 +818,46 @@ def test_responses_stream_events_v3_emits_reasoning_lifecycle() -> None:
     )
 
     # Finish events must carry the accumulated reasoning text.
+    reasoning_texts = [
+        cast("dict[str, Any]", f["content"])["reasoning"] for f in reasoning_finishes
+    ]
+    assert reasoning_texts == [
+        "reasoning block one",
+        "another reasoning block",
+        "more reasoning",
+        "still more reasoning",
+    ]
+
+
+async def test_aresponses_stream_events_v3_emits_reasoning_lifecycle() -> None:
+    """Async twin of `test_responses_stream_events_v3_emits_reasoning_lifecycle`.
+
+    Drives the native async Responses converter via `astream_events(version="v3")`
+    and asserts the same four reasoning `content-block-finish` events with their
+    accumulated text.
+    """
+    llm = ChatOpenAI(model="o4-mini", use_responses_api=True, output_version="v1")
+    mock_client = MagicMock()
+
+    async def mock_create(*args: Any, **kwargs: Any) -> MockAsyncContextManager:
+        return MockAsyncContextManager(responses_stream)
+
+    mock_client.responses.create = mock_create
+
+    with patch.object(llm, "root_async_client", mock_client):
+        stream = await llm.astream_events("test", version="v3")
+        events = [e async for e in stream]
+
+    assert_valid_event_stream(events)
+
+    reasoning_finishes = [
+        e
+        for e in events
+        if e["event"] == "content-block-finish" and e["content"]["type"] == "reasoning"
+    ]
+    assert len(reasoning_finishes) == 4, (
+        f"expected 4 reasoning finish events, got {len(reasoning_finishes)}"
+    )
     reasoning_texts = [
         cast("dict[str, Any]", f["content"])["reasoning"] for f in reasoning_finishes
     ]

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream_events.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_responses_stream_events.py
@@ -1,0 +1,103 @@
+"""Unit tests for the OpenAI Responses API native stream-events converter."""
+
+from typing import Any, cast
+
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+
+from langchain_openai.chat_models._stream_events import (
+    convert_openai_responses_stream,
+)
+from langchain_openai.chat_models.base import (
+    _convert_responses_chunk_to_generation_chunk,
+)
+
+# The shared fixture used by the existing bridge parity test.
+from tests.unit_tests.chat_models.test_responses_stream import responses_stream
+
+
+def test_convert_openai_responses_reasoning_lifecycle() -> None:
+    events: list[Any] = list(
+        convert_openai_responses_stream(
+            iter(responses_stream),
+            _convert_responses_chunk_to_generation_chunk,
+            output_version="v1",
+        )
+    )
+    assert_valid_event_stream(events)
+
+    # message-start must NOT carry the provider response id (consistency with
+    # the bridge / the rule from Phases 1-3): empty id lets core's seeded run id
+    # stand.
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "openai"
+
+    reasoning_finishes = [
+        e
+        for e in events
+        if e["event"] == "content-block-finish" and e["content"]["type"] == "reasoning"
+    ]
+    assert len(reasoning_finishes) == 4
+    assert [
+        cast("dict[str, Any]", f["content"])["reasoning"] for f in reasoning_finishes
+    ] == [
+        "reasoning block one",
+        "another reasoning block",
+        "more reasoning",
+        "still more reasoning",
+    ]
+    assert events[-1]["event"] == "message-finish"
+
+
+def test_convert_openai_responses_true_boundaries() -> None:
+    """A block finishes before the next block's content arrives (true boundary)."""
+    events: list[Any] = list(
+        convert_openai_responses_stream(
+            iter(responses_stream),
+            _convert_responses_chunk_to_generation_chunk,
+            output_version="v1",
+        )
+    )
+    # The first content-block-finish must precede the start of a later index.
+    first_finish_idx = next(
+        i for i, e in enumerate(events) if e["event"] == "content-block-finish"
+    )
+    later_start_idx = next(
+        (
+            i
+            for i, e in enumerate(events)
+            if e["event"] == "content-block-start"
+            and e["index"] > events[first_finish_idx]["index"]
+        ),
+        None,
+    )
+    # If there is a higher-index block, its start comes after the prior finish.
+    if later_start_idx is not None:
+        assert first_finish_idx < later_start_idx
+
+
+async def test_aconvert_openai_responses_reasoning_lifecycle() -> None:
+    async def _araw() -> Any:
+        for c in responses_stream:
+            yield c
+
+    from langchain_openai.chat_models._stream_events import (
+        aconvert_openai_responses_stream,
+    )
+
+    events: list[Any] = [
+        e
+        async for e in aconvert_openai_responses_stream(
+            _araw(),
+            _convert_responses_chunk_to_generation_chunk,
+            output_version="v1",
+        )
+    ]
+    assert_valid_event_stream(events)
+    reasoning_finishes = [
+        e
+        for e in events
+        if e["event"] == "content-block-finish" and e["content"]["type"] == "reasoning"
+    ]
+    assert len(reasoning_finishes) == 4
+    assert events[-1]["event"] == "message-finish"

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_stream_events.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_stream_events.py
@@ -1,0 +1,291 @@
+"""Unit tests for the OpenAI Chat Completions native stream-events converter."""
+
+from typing import Any, cast
+
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
+from pydantic import SecretStr
+
+from langchain_openai import ChatOpenAI
+from langchain_openai.chat_models._stream_events import (
+    convert_openai_completions_stream,
+)
+
+
+def _text_chunks() -> list[dict]:
+    cid = "chatcmpl-1"
+    return [
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {"index": 0, "delta": {"content": "Hello"}, "finish_reason": None}
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {"index": 0, "delta": {"content": " world"}, "finish_reason": None}
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 2, "total_tokens": 9},
+        },
+    ]
+
+
+def _tool_chunks() -> list[dict]:
+    cid = "chatcmpl-2"
+    return [
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {
+                                "index": 0,
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "get_weather", "arguments": ""},
+                            }
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": '{"city":'}}
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "tool_calls": [
+                            {"index": 0, "function": {"arguments": ' "Paris"}'}}
+                        ]
+                    },
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": cid,
+            "model": "gpt-4o",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+            "usage": None,
+        },
+    ]
+
+
+def test_convert_openai_completions_text_lifecycle() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()), llm._convert_chunk_to_generation_chunk
+        )
+    )
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    # The provider completion id is deliberately NOT used as the message-start
+    # id: on the v3 path core seeds the stream with the LangChain run id, and an
+    # empty id here lets that stand (matching the compat bridge).
+    assert events[0]["id"] == ""
+    assert events[0]["metadata"]["provider"] == "openai"
+    text = "".join(
+        e["delta"].get("text", "")
+        for e in events
+        if e["event"] == "content-block-delta"
+        and e["delta"].get("type") == "text-delta"
+    )
+    assert text == "Hello world"
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    assert [f["content"]["type"] for f in finishes] == ["text"]
+    assert cast("dict[str, Any]", finishes[0]["content"])["text"] == "Hello world"
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["usage"] == {
+        "input_tokens": 7,
+        "output_tokens": 2,
+        "total_tokens": 9,
+    }
+    assert message_finish["metadata"]["finish_reason"] == "stop"
+
+
+def test_convert_openai_completions_tool_call() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_tool_chunks()), llm._convert_chunk_to_generation_chunk
+        )
+    )
+    assert_valid_event_stream(events)
+    finishes = [e for e in events if e["event"] == "content-block-finish"]
+    tool_finishes = [f for f in finishes if f["content"]["type"] == "tool_call"]
+    assert len(tool_finishes) == 1
+    tc = cast("dict[str, Any]", tool_finishes[0]["content"])
+    assert tc["name"] == "get_weather"
+    assert tc["args"] == {"city": "Paris"}
+
+
+def test_explicit_message_id_is_used() -> None:
+    """An explicit `message_id` (e.g. the v3 stream's run id) is honored."""
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()),
+            llm._convert_chunk_to_generation_chunk,
+            message_id="lc_run--abc",
+        )
+    )
+    assert events[0]["event"] == "message-start"
+    assert events[0]["id"] == "lc_run--abc"
+
+
+def test_provider_override_is_not_clobbered_by_openai() -> None:
+    """Reuse with a non-OpenAI `provider` must not be relabeled `openai`.
+
+    `_convert_chunk_to_generation_chunk` hardcodes `model_provider="openai"`;
+    the converter must re-apply the caller's `provider` so OpenAI-compatible
+    providers (groq, deepseek, ...) stay correctly labeled on both
+    `message-start` and `message-finish`.
+    """
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+    events: list[Any] = list(
+        convert_openai_completions_stream(
+            iter(_text_chunks()),
+            llm._convert_chunk_to_generation_chunk,
+            provider="groq",
+        )
+    )
+    assert events[0]["metadata"]["provider"] == "groq"
+    message_finish = events[-1]
+    assert message_finish["event"] == "message-finish"
+    assert message_finish["metadata"]["model_provider"] == "groq"
+
+
+async def test_aconvert_openai_completions_text_lifecycle() -> None:
+    llm = ChatOpenAI(model="gpt-4o", api_key=SecretStr("test"))
+
+    async def _araw() -> Any:
+        for c in _text_chunks():
+            yield c
+
+    from langchain_openai.chat_models._stream_events import (
+        aconvert_openai_completions_stream,
+    )
+
+    events: list[Any] = [
+        e
+        async for e in aconvert_openai_completions_stream(
+            _araw(), llm._convert_chunk_to_generation_chunk
+        )
+    ]
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[-1]["event"] == "message-finish"
+    text = "".join(
+        e["delta"].get("text", "")
+        for e in events
+        if e["event"] == "content-block-delta"
+        and e["delta"].get("type") == "text-delta"
+    )
+    assert text == "Hello world"
+
+
+def test_response_format_in_model_kwargs_takes_bridge_path() -> None:
+    """`response_format` baked into `model_kwargs` must defer to the bridge.
+
+    The native completions converter lacks the beta structured-output
+    `get_final_completion()` flow, so such models must route through
+    `_stream` (the bridge), never the native converter.
+    """
+    from unittest.mock import patch
+
+    from langchain_core.messages import AIMessageChunk
+    from langchain_core.outputs import ChatGenerationChunk
+
+    from langchain_openai.chat_models import base
+
+    llm = ChatOpenAI(
+        model="gpt-4o",
+        api_key=SecretStr("test"),
+        model_kwargs={"response_format": {"type": "json_object"}},
+    )
+
+    def _fake_stream(*args: Any, **kwargs: Any) -> Any:
+        yield ChatGenerationChunk(message=AIMessageChunk(content="hi"))
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        msg = "native converter must not run for model_kwargs response_format"
+        raise AssertionError(msg)
+
+    with (
+        patch.object(llm, "_stream", _fake_stream),
+        patch.object(base, "convert_openai_completions_stream", _boom),
+    ):
+        events: list[Any] = list(
+            llm._stream_chat_model_events([], stop=None, run_manager=None)
+        )
+
+    # Bridge path produced events from the patched `_stream` without ever
+    # entering the native converter (which would have raised).
+    assert events
+    assert events[0]["event"] == "message-start"
+    assert events[-1]["event"] == "message-finish"

--- a/libs/partners/openai/tests/unit_tests/test_imports.py
+++ b/libs/partners/openai/tests/unit_tests/test_imports.py
@@ -10,7 +10,9 @@ EXPECTED_ALL = [
     "AzureOpenAIEmbeddings",
     "StreamChunkTimeoutError",
     "aconvert_openai_completions_stream",
+    "aconvert_openai_responses_stream",
     "convert_openai_completions_stream",
+    "convert_openai_responses_stream",
     "custom_tool",
 ]
 

--- a/libs/partners/openai/tests/unit_tests/test_imports.py
+++ b/libs/partners/openai/tests/unit_tests/test_imports.py
@@ -9,6 +9,8 @@ EXPECTED_ALL = [
     "AzureChatOpenAI",
     "AzureOpenAIEmbeddings",
     "StreamChunkTimeoutError",
+    "aconvert_openai_completions_stream",
+    "convert_openai_completions_stream",
     "custom_tool",
 ]
 

--- a/libs/partners/xai/langchain_xai/chat_models.py
+++ b/libs/partners/xai/langchain_xai/chat_models.py
@@ -603,6 +603,10 @@ class ChatXAI(BaseChatOpenAI):  # type: ignore[override]
 
         return rtn
 
+    @property
+    def _stream_event_provider(self) -> str:
+        return "xai"
+
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,

--- a/libs/partners/xai/tests/unit_tests/test_chat_models.py
+++ b/libs/partners/xai/tests/unit_tests/test_chat_models.py
@@ -1,4 +1,6 @@
 import json
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest  # type: ignore[import-not-found]
 from langchain_core.messages import (
@@ -12,7 +14,9 @@ from langchain_openai.chat_models.base import (
     _convert_dict_to_message,
     _convert_message_to_dict,
 )
+from langchain_tests.utils.stream_lifecycle import assert_valid_event_stream
 from pydantic import SecretStr
+from typing_extensions import Self
 
 from langchain_xai import ChatXAI
 
@@ -171,3 +175,65 @@ def test_metadata_versions() -> None:
     assert "langchain-core" in versions
     assert "langchain-xai" in versions
     assert "langchain-openai" in versions
+
+
+class _MockSyncContextManager:
+    """Minimal context manager yielding OpenAI-shaped completions chunks."""
+
+    def __init__(self, chunks: list) -> None:
+        self._chunks = iter(chunks)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> dict:
+        return next(self._chunks)
+
+
+def test_xai_stream_events_v3_provider_label() -> None:
+    """xai's native v3 stream labels `model_provider` as 'xai'."""
+    # `grok-4` takes the Chat Completions path (not Responses), so the
+    # inherited native hook calls `self.client.create(**payload)`.
+    chunks = [
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "hi"},
+                    "finish_reason": None,
+                }
+            ],
+            "usage": None,
+        },
+        {
+            "id": "x",
+            "model": MODEL_NAME,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": None,
+        },
+    ]
+
+    llm = ChatXAI(model=MODEL_NAME, api_key=SecretStr("x"))
+    assert llm._use_responses_api({}) is False
+    mock_client = MagicMock()
+
+    def mock_create(*_args: Any, **_kwargs: Any) -> _MockSyncContextManager:
+        return _MockSyncContextManager(chunks)
+
+    mock_client.create = mock_create
+    with patch.object(llm, "client", mock_client):
+        events: list[Any] = list(llm.stream_events("hi", version="v3"))
+
+    assert_valid_event_stream(events)
+    assert events[0]["event"] == "message-start"
+    assert events[0]["metadata"]["provider"] == "xai"
+    assert events[-1]["event"] == "message-finish"
+    assert events[-1]["metadata"]["model_provider"] == "xai"


### PR DESCRIPTION
> Stacked on #324 → #325 → #326. Review/merge those first; retargets to `master` as they land.

`ChatDeepSeek` and `ChatXAI` subclass `BaseChatOpenAI`, so they already inherit the native `stream_events(version="v3")` hooks added for OpenAI. The only missing piece was the provider label: the converters re-apply `provider`, which defaulted to `"openai"` and mislabeled deepseek/xai output.

### What it does

Adds a small `_stream_event_provider` property on `BaseChatOpenAI` (default `"openai"`) that the native hooks pass to the converters, mirroring LangChain.js's `streamEventProvider`. `ChatDeepSeek` overrides it to `"deepseek"` and `ChatXAI` to `"xai"` — one line each. No new converters: deepseek reuses the Chat Completions converter, and xai reuses both Completions and (via its existing `_use_responses_api` routing) the Responses converter.

With this, `model_provider` is labeled correctly on both `message-start.metadata` and `message-finish.metadata`, consistent with the chunk-level provider these classes already set.

### Scope

Only the two genuine `BaseChatOpenAI` subclasses. `fireworks`, `groq`, and `openrouter` subclass `BaseChatModel` with their own SDK clients and are already served by the compat bridge; bringing them onto native converters (via per-provider chunk adapters) is a separate, lower-value decision and is intentionally **not** included here.

### Worth careful review

- `ChatOpenAI` itself is unchanged (the property defaults to `"openai"`); the existing OpenAI v3 tests pass as-is.
- The per-provider tests drive `stream_events(version="v3")` through the inherited native hook (mocking the OpenAI client) and assert the provider label end-to-end; they fail without the override (TDD).