### PR TITLE
fix(openai): force stream=False in _generate/_agenerate when disable_streaming is active

### DIFF
--- a/libs/core/langchain_core/language_models/chat_models.py
+++ b/libs/core/langchain_core/language_models/chat_models.py
@@ -306,7 +306,9 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
     - If `'tool_calling'`, will bypass streaming case only when the model is called
         with a `tools` keyword argument. In other words, LangChain will automatically
         switch to non-streaming behavior (`invoke`) only when the tools argument is
-        provided. This offers the best of both worlds.
+        provided. Note that this disables streaming for *all* turns when tools are
+        bound (e.g., via ``bind_tools``), not only for turns that actually produce
+        tool calls, since the response content is unknown before the API call.
     - If `False` (Default), will always use streaming case if available.
 
     The main reason for this flag is that code might be written using `stream` and
@@ -460,6 +462,11 @@ class BaseChatModel(BaseLanguageModel[AIMessage], ABC):
         if self.disable_streaming is True:
             return False
         # We assume tools are passed in via "tools" kwarg in all models.
+        # Note: this checks whether tools are *bound* to the model, not whether the
+        # current response will contain tool calls. Since we cannot know the response
+        # content before making the API call, setting disable_streaming="tool_calling"
+        # will disable streaming for ALL turns when tools are bound (e.g., via
+        # bind_tools), not only for turns that actually produce tool calls.
         if self.disable_streaming == "tool_calling" and kwargs.get("tools"):
             return False
 

--- a/libs/partners/openai/langchain_openai/chat_models/base.py
+++ b/libs/partners/openai/langchain_openai/chat_models/base.py
@@ -1436,6 +1436,10 @@ class BaseChatOpenAI(BaseChatModel):
     ) -> ChatResult:
         self._ensure_sync_client_available()
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # Ensure stream is False. _default_params may set stream=True based on
+        # self.streaming, but when disable_streaming (e.g., "tool_calling") routes
+        # execution here instead of _stream, we must override it.
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:
@@ -1690,6 +1694,10 @@ class BaseChatOpenAI(BaseChatModel):
         **kwargs: Any,
     ) -> ChatResult:
         payload = self._get_request_payload(messages, stop=stop, **kwargs)
+        # Ensure stream is False. _default_params may set stream=True based on
+        # self.streaming, but when disable_streaming (e.g., "tool_calling") routes
+        # execution here instead of _astream, we must override it.
+        payload["stream"] = False
         generation_info = None
         raw_response = None
         try:

--- a/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
+++ b/libs/partners/openai/tests/unit_tests/chat_models/test_base.py
@@ -3431,3 +3431,77 @@ def test_context_overflow_error_backwards_compatibility() -> None:
     # Verify it's both types (multiple inheritance)
     assert isinstance(exc_info.value, openai.BadRequestError)
     assert isinstance(exc_info.value, ContextOverflowError)
+
+
+def test_disable_streaming_tool_calling_forces_stream_false(
+    mock_completion: dict,
+) -> None:
+    """Test that _generate sets stream=False when disable_streaming is active.
+
+    When streaming=True and disable_streaming="tool_calling", the _should_stream
+    check routes execution to _generate instead of _stream. But _default_params
+    includes stream=True from self.streaming. _generate must override this to
+    stream=False, otherwise the OpenAI client returns a Stream object and
+    _create_chat_result crashes calling .model_dump() on it.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35436
+    """
+    llm = ChatOpenAI(
+        model="gpt-4o",
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+    # Verify _default_params has stream=True (the root cause of the bug).
+    assert llm._default_params["stream"] is True
+
+    call_payloads: list[dict] = []
+
+    mock_client = MagicMock()
+    mock_resp = MagicMock()
+    mock_resp.headers = {"content-type": "application/json"}
+    mock_resp.parse.return_value = mock_completion
+    mock_client.with_raw_response.create = MagicMock(
+        side_effect=lambda **kw: (call_payloads.append(kw), mock_resp)[1]
+    )
+
+    with patch.object(llm, "client", mock_client):
+        tools = [{"type": "function", "function": {"name": "t", "parameters": {}}}]
+        result = llm.invoke("hello", tools=tools)
+
+    assert result.content == "Bar Baz"
+    # The critical assertion: stream must be False in the actual API call payload.
+    assert call_payloads[-1]["stream"] is False
+
+
+async def test_disable_streaming_tool_calling_forces_stream_false_async(
+    mock_completion: dict,
+) -> None:
+    """Async version: _agenerate sets stream=False when disable_streaming is active.
+
+    Regression test for https://github.com/langchain-ai/langchain/issues/35436
+    """
+    llm = ChatOpenAI(
+        model="gpt-4o",
+        streaming=True,
+        disable_streaming="tool_calling",
+    )
+    assert llm._default_params["stream"] is True
+
+    call_payloads: list[dict] = []
+
+    mock_client = AsyncMock()
+    mock_resp = MagicMock()
+    mock_resp.parse.return_value = mock_completion
+
+    async def mock_create(**kwargs: Any) -> MagicMock:
+        call_payloads.append(kwargs)
+        return mock_resp
+
+    mock_client.with_raw_response.create = mock_create
+
+    with patch.object(llm, "async_client", mock_client):
+        tools = [{"type": "function", "function": {"name": "t", "parameters": {}}}]
+        result = await llm.ainvoke("hello", tools=tools)
+
+    assert result.content == "Bar Baz"
+    assert call_payloads[-1]["stream"] is False


### PR DESCRIPTION
## Summary

- **Bug**: When `streaming=True` and `disable_streaming="tool_calling"` with tools bound, `_should_stream()` correctly routes to `_generate`/`_agenerate`. But `_default_params` still sets `stream=True` from `self.streaming`, so the OpenAI API returns a Stream object. `_create_chat_result` then crashes calling `.model_dump()` on it.
- **Fix**: Explicitly set `payload["stream"] = False` in both `BaseChatOpenAI._generate` and `BaseChatOpenAI._agenerate` after building the payload, since these are non-streaming code paths.
- **Docs**: Clarify in the `disable_streaming` field docstring and `_should_stream` comments that `"tool_calling"` disables streaming for all turns when tools are bound (not just tool-call turns), since the response content is unknown before the API call.

Closes #246

## Areas requiring careful review

- The `payload["stream"] = False` override in `_generate`/`_agenerate` is unconditional. This is intentional -- these methods are the non-streaming code paths and should never send `stream=True`. The existing `response_format` branch already pops `stream` entirely, so this is consistent.

## Test plan

- [x] New sync test: `test_disable_streaming_tool_calling_forces_stream_false` -- verifies `stream=False` in the API payload when `streaming=True` + `disable_streaming="tool_calling"` + tools bound
- [x] New async test: `test_disable_streaming_tool_calling_forces_stream_false_async` -- same for async path
- [x] All 183 existing tests in `tests/unit_tests/chat_models/test_base.py` pass
- [x] All 12 core `disable_streaming` tests pass

---

> [!NOTE]
> This contribution was developed with assistance from an AI agent (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)