### PR TITLE
fix(core): remove str coercion in `get_from_dict_or_env`

### DIFF
--- a/libs/core/langchain_core/utils/env.py
+++ b/libs/core/langchain_core/utils/env.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import TypeVar
+
+V = TypeVar("V")
 
 
 def env_var_is_set(env_var: str) -> bool:
@@ -24,11 +26,11 @@ def env_var_is_set(env_var: str) -> bool:
 
 
 def get_from_dict_or_env(
-    data: dict[str, Any],
+    data: dict[str, V],
     key: str | list[str],
     env_key: str,
     default: str | None = None,
-) -> str:
+) -> V | str:
     """Get a value from a dictionary or an environment variable.
 
     Args:
@@ -47,10 +49,10 @@ def get_from_dict_or_env(
     if isinstance(key, (list, tuple)):
         for k in key:
             if value := data.get(k):
-                return str(value)
+                return value
 
     if isinstance(key, str) and key in data and data[key]:
-        return str(data[key])
+        return data[key]
 
     key_for_err = key[0] if isinstance(key, (list, tuple)) else key
 


### PR DESCRIPTION
`get_from_dict_or_env` accepted `dict[str, Any]` but declared `-> str`, and #34204 papered over the mismatch by adding `str()` casts to satisfy mypy. 

That silently broke callers passing non-string dict values (enums, `SecretStr`, etc.).

Fix the actual root cause: the return type was wrong.

Closes #253.